### PR TITLE
Mask people during gsplat training

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ and `pano_mapping_cubemap/gsplat_output` (the trained model). Set
 `DOCKER_IMAGE` to use a locally built image instead of the published one. The
 script keeps downloaded PyTorch model weights in the persistent Docker volume
 `easygaussiansplatting-torch-cache`, so later runs reuse them.
+Existing person-segmentation masks are reused on later runs.
 
 ![COLMAP sparse reconstruction viewer](assets/reconstruction_viewer.jpg)
 
@@ -151,7 +152,7 @@ so retraining an existing cube-map model needs no pipeline rerun. The
 directory must live under the repo checkout:
 
 ```
-scripts/run_gsplat.sh data/panorama 30000 2
+scripts/run_gsplat.sh data/panorama 30000 1 0.01
 ```
 
 The trained model lands in `<cubemap_reconstruction_dir>/gsplat_output/`,

--- a/mapping/segment_people.py
+++ b/mapping/segment_people.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Segment people in a COLMAP image folder and write gsplat training masks.
+
+Masks are white where gsplat should supervise training and black over people,
+named "<image_name>.png" after the image they belong to (COLMAP's mask naming
+convention).
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+from torchvision.models.detection import (
+    MaskRCNN_ResNet50_FPN_V2_Weights,
+    maskrcnn_resnet50_fpn_v2,
+)
+from torchvision.transforms.functional import to_tensor
+
+PERSON_LABEL = 1  # COCO
+IMAGE_SUFFIXES = (".jpg", ".jpeg", ".png")
+
+
+def person_mask(model, image, device, score_threshold, mask_threshold, dilation):
+    """Return a uint8 mask: 255 where training should look, 0 over people."""
+    tensor = to_tensor(image).to(device)
+    with torch.inference_mode():
+        prediction = model([tensor])[0]
+
+    people = (prediction["labels"] == PERSON_LABEL) & (
+        prediction["scores"] >= score_threshold
+    )
+    height, width = tensor.shape[1:]
+    if not bool(people.any()):
+        return np.full((height, width), 255, dtype=np.uint8)
+
+    person = (prediction["masks"][people, 0].amax(0) >= mask_threshold).float()
+    if dilation > 0:
+        # Grows the mask over the soft edges the segmenter leaves behind:
+        # motion blur, hair, and the contact shadow under the feet.
+        person = torch.nn.functional.max_pool2d(
+            person[None], kernel_size=2 * dilation + 1, stride=1, padding=dilation
+        )[0]
+    return ((person < 0.5).to(torch.uint8) * 255).cpu().numpy()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image_dir", type=Path)
+    parser.add_argument("mask_dir", type=Path)
+    parser.add_argument("--score-threshold", type=float, default=0.5)
+    parser.add_argument("--mask-threshold", type=float, default=0.5)
+    parser.add_argument(
+        "--dilation", type=int, default=8, help="pixels to grow each person mask by"
+    )
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    image_paths = sorted(
+        path
+        for path in args.image_dir.iterdir()
+        if path.suffix.lower() in IMAGE_SUFFIXES
+    )
+    if not image_paths:
+        raise SystemExit(f"No images found in {args.image_dir}")
+
+    args.mask_dir.mkdir(parents=True, exist_ok=True)
+    pending_image_paths = [
+        image_path
+        for image_path in image_paths
+        if args.overwrite or not (args.mask_dir / f"{image_path.name}.png").exists()
+    ]
+    if not pending_image_paths:
+        print(f"Masks already exist in {args.mask_dir}; skipping segmentation")
+        return
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    weights = MaskRCNN_ResNet50_FPN_V2_Weights.DEFAULT
+    model = maskrcnn_resnet50_fpn_v2(weights=weights).eval().to(device)
+
+    masked_images = 0
+    for count, image_path in enumerate(pending_image_paths, start=1):
+        mask_path = args.mask_dir / f"{image_path.name}.png"
+        image = Image.open(image_path).convert("RGB")
+        mask = person_mask(
+            model,
+            image,
+            device,
+            args.score_threshold,
+            args.mask_threshold,
+            args.dilation,
+        )
+        Image.fromarray(mask).save(mask_path)
+        masked_images += int((mask == 0).any())
+        print(f"[{count}/{len(pending_image_paths)}] {mask_path.name}", flush=True)
+
+    print(f"Masks written to {args.mask_dir} ({masked_images} images contain people)")
+
+
+if __name__ == "__main__":
+    main()

--- a/mapping/train_gsplat_with_masks.py
+++ b/mapping/train_gsplat_with_masks.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Run gsplat's simple_trainer with the per-image masks segment_people.py writes.
+
+gsplat's COLMAP dataset only carries one mask per camera (the undistortion
+ROI), so per-image masks are attached here instead: its __getitem__ is wrapped
+to load "<data_dir>/masks/<image_name>.png" alongside each image. Takes
+simple_trainer's own arguments.
+"""
+import os
+import runpy
+import sys
+
+import numpy as np
+import torch
+from PIL import Image
+
+EXAMPLES_DIR = "/opt/gsplat/examples"
+
+
+def attach_masks(dataset_class):
+    original_getitem = dataset_class.__getitem__
+
+    def __getitem__(self, item):
+        data = original_getitem(self, item)
+        image_name = self.parser.image_names[self.indices[item]]
+        mask_path = os.path.join(self.parser.data_dir, "masks", f"{image_name}.png")
+        if not os.path.exists(mask_path):
+            return data
+
+        assert self.patch_size is None, "masks are not cropped along with patches"
+        height, width = data["image"].shape[:2]
+        mask = Image.open(mask_path).resize((width, height), Image.NEAREST)
+        mask = torch.from_numpy(np.asarray(mask) > 127)
+        # An all-black mask leaves the losses averaging over no pixels at all,
+        # which trains on NaN from there on.
+        if mask.any():
+            data["mask"] = mask
+        return data
+
+    dataset_class.__getitem__ = __getitem__
+
+
+sys.path.insert(0, EXAMPLES_DIR)
+from datasets.colmap import Dataset  # noqa: E402
+
+attach_masks(Dataset)
+runpy.run_path(os.path.join(EXAMPLES_DIR, "simple_trainer.py"), run_name="__main__")

--- a/scripts/gsplat_env.sh
+++ b/scripts/gsplat_env.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Activate the container's gsplat conda env. Source it; don't execute it.
+
+source /opt/miniconda3/etc/profile.d/conda.sh
+# conda's cuda-nvcc activation hook references NVCC_PREPEND_FLAGS without a
+# default, which trips the callers' `set -u`.
+set +u
+conda activate gsplat
+set -u

--- a/scripts/gsplat_train.sh
+++ b/scripts/gsplat_train.sh
@@ -17,15 +17,11 @@ FLOATER_REG_WEIGHT="${4:-0.01}"
 
 RESULT_DIR="${CUBEMAP_DIR}/gsplat_output"
 
-source /opt/miniconda3/etc/profile.d/conda.sh
-# conda's cuda-nvcc activation hook references NVCC_PREPEND_FLAGS without a
-# default, which trips `set -u` above.
-set +u
-conda activate gsplat
-set -u
-cd /opt/gsplat/examples
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/gsplat_env.sh"
+
 export PYTORCH_ALLOC_CONF="${PYTORCH_ALLOC_CONF:-expandable_segments:True}"
-python3 simple_trainer.py default \
+python3 "${SCRIPT_DIR}/../mapping/train_gsplat_with_masks.py" default \
   --data_dir "${CUBEMAP_DIR}" \
   --data_factor "${DATA_FACTOR}" \
   --max_steps "${ITERATIONS}" \

--- a/scripts/run_gsplat.sh
+++ b/scripts/run_gsplat.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Train a Gaussian Splatting model with gsplat from an existing cube-map
-# reconstruction (see cubemap_convert.sh), via the project's Docker image.
+# Mask out people and train a Gaussian Splatting model with gsplat from an
+# existing cube-map reconstruction (see cubemap_convert.sh), via the project's
+# Docker image.
 # Runs on the host (not inside the container) and drives `docker run` itself.
 set -euo pipefail
 
@@ -16,8 +17,14 @@ ITERATIONS="${2:-30000}"
 DATA_FACTOR="${3:-1}"
 FLOATER_REG_WEIGHT="${4:-0.01}"
 
-docker run "${DOCKER_RUN_FLAGS[@]}" "${DOCKER_IMAGE}" \
-  scripts/gsplat_train.sh "/workspace/${REL_CUBEMAP_DIR}" \
-  "${ITERATIONS}" "${DATA_FACTOR}" "${FLOATER_REG_WEIGHT}"
+docker run "${DOCKER_RUN_FLAGS[@]}" \
+  -e CUBEMAP_DIR="/workspace/${REL_CUBEMAP_DIR}" \
+  -e ITERATIONS="${ITERATIONS}" \
+  -e DATA_FACTOR="${DATA_FACTOR}" \
+  -e FLOATER_REG_WEIGHT="${FLOATER_REG_WEIGHT}" \
+  "${DOCKER_IMAGE}" \
+  bash -c 'set -euo pipefail
+scripts/segment_people.sh "$CUBEMAP_DIR"
+scripts/gsplat_train.sh "$CUBEMAP_DIR" "$ITERATIONS" "$DATA_FACTOR" "$FLOATER_REG_WEIGHT"'
 
 echo "Model written to ${REPO_ROOT}/${REL_CUBEMAP_DIR}/gsplat_output"

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -41,6 +41,7 @@ docker run "${DOCKER_RUN_FLAGS[@]}" \
 scripts/stitch_pano.sh
 scripts/colmap_reconstruct.sh "$OUTPUT_VIDEO" "$FRAME_RATE"
 scripts/cubemap_convert.sh "$RECONSTRUCTION_DIR" "$FACE_SIZE"
+scripts/segment_people.sh "${RECONSTRUCTION_DIR}_cubemap"
 scripts/gsplat_train.sh "${RECONSTRUCTION_DIR}_cubemap" "$GS_ITERATIONS" "$GS_DATA_FACTOR" "$GS_FLOATER_REG_WEIGHT"'
 
 echo "Model written to ${REPO_ROOT}/${REL_RECONSTRUCTION_DIR}_cubemap/gsplat_output"

--- a/scripts/segment_people.sh
+++ b/scripts/segment_people.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Mask out people in a cube-map reconstruction's images (see cubemap_convert.sh)
+# so gsplat doesn't train on passers-by. Run inside the container.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <cubemap_reconstruction_dir> [score_threshold] [dilation]" >&2
+  exit 1
+fi
+
+CUBEMAP_DIR="$(cd "$1" && pwd)"
+SCORE_THRESHOLD="${2:-0.5}"
+DILATION="${3:-8}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/gsplat_env.sh"
+
+python3 "${SCRIPT_DIR}/../mapping/segment_people.py" \
+  "${CUBEMAP_DIR}/images" "${CUBEMAP_DIR}/masks" \
+  --score-threshold "${SCORE_THRESHOLD}" --dilation "${DILATION}"


### PR DESCRIPTION
## Summary
- add cached person segmentation masks for cube-map images
- use masks in the gsplat trainer for full-pipeline and gsplat-only runs
- document mask reuse and current training arguments

## Validation
- bash -n scripts/gsplat_env.sh scripts/gsplat_train.sh scripts/run_gsplat.sh scripts/run_pipeline.sh scripts/segment_people.sh
- python3 -m py_compile mapping/segment_people.py mapping/train_gsplat_with_masks.py
- git diff --cached --check