### PR TITLE
Document the gsplat server on Linux, and split the host guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This branch is a ground-up remake of the pipeline. What's done so far:
 - [x] Script to run COLMAP reconstruction via `panorama_sfm`
 - [x] Script to convert an equirect COLMAP reconstruction to a cube-map one
 - [x] Script to train a Gaussian Splatting model from the cube-map reconstruction (gsplat)
-- [x] gRPC training server for a Jetson AGX Orin
+- [x] gRPC training server
 - [ ] Export/viewer wired to the above
 
 ## What's in the Docker image
@@ -76,15 +76,16 @@ docker build -f artifacts/docker/dev.dockerfile -t easygaussiansplatting:dev \
   --build-context colmapsrc=./third_party/colmap artifacts/docker
 ```
 
-## Training on a Jetson AGX Orin
+## Training over gRPC
 
-`gsplat_server/` is a separate arm64 image that turns an Orin into a training
-appliance: clients stream a zipped COLMAP model over gRPC, the Orin trains it, and they
-download the point cloud. See [doc/gsplat_server.md](doc/gsplat_server.md).
+`gsplat_server/` turns a GPU host into a training appliance: clients stream a
+zipped COLMAP model over gRPC, the host trains it, and they download the point
+cloud. [doc/gsplat_server.md](doc/gsplat_server.md) covers it on an x86_64
+Linux host and links the Jetson AGX Orin and Windows guides.
 
 ```
-gsplat_server/run_server.sh                     # on the Orin
-gsplat_server/client.py data/pano_mapping_cubemap --server orin:50051
+gsplat_server/run_server.sh                     # on the GPU host
+gsplat_server/client.py data/pano_mapping_cubemap --server gsplat-host:50051
 ```
 
 ## Using the tools

--- a/doc/gsplat_server.md
+++ b/doc/gsplat_server.md
@@ -1,70 +1,120 @@
-# Gaussian Splatting server on a Jetson AGX Orin
+# Gaussian Splatting server on Linux
 
-`gsplat_server/` turns an Orin into a training appliance: clients upload a COLMAP
-model over gRPC, the Orin trains it with gsplat, and they download the resulting
-point cloud. It carries only the training half of the pipeline — clients run
-COLMAP and `scripts/cubemap_convert.sh` themselves, since gsplat's COLMAP loader
-accepts only perspective and fisheye cameras.
+`gsplat_server/` turns a Linux box with an NVIDIA GPU into a training
+appliance: clients upload a COLMAP model over gRPC, the server trains it with
+gsplat, and they download the resulting point cloud. It carries only the
+training half of the pipeline — clients run COLMAP and
+`scripts/cubemap_convert.sh` themselves, since gsplat's COLMAP loader accepts
+only perspective and fisheye cameras.
 
 | File | |
 | --- | --- |
-| `jetson.dockerfile` | arm64 image: JetPack 6 (L4T r36.4, CUDA 12.6) plus gsplat. |
-| `install_gsplat.sh` | Image installation script. |
+| `artifacts/docker/dev.dockerfile` | x86_64 image: COLMAP, the gsplat conda env, and the pipeline tools. |
+| `artifacts/docker/installers/install_gsplat.sh` | Image installation script for the gsplat env. |
 | `server.py` | The gRPC service and its job queue. |
 | `serve.sh` | Container: start the service. |
 | `run_server.sh` | Host: start the service via Docker. |
 | `client.py` | Command-line gRPC client. Requires `grpcio`. |
 | `proto/build.sh` | Generates ignored Python bindings from `proto/gsplat.proto`. |
 
+## Prerequisites
+
+* x86_64 Linux with Docker, an NVIDIA driver, and the NVIDIA Container
+  Toolkit, so `docker run --gpus all` reaches the GPU.
+* A checkout of this repo on the host, which the container runs bind-mounted at
+  `/workspace`.
+* `protoc` and the gRPC Python plugin, to generate the bindings below:
+  `sudo apt install protobuf-compiler protobuf-compiler-grpc`.
+
 ## Getting the image
 
 CI publishes it on every push to `master`:
 
 ```
-docker pull ghcr.io/mapmindai/gaussiansplatting-jetson:latest
+docker pull ghcr.io/mapmindai/gaussiansplatting:latest
 ```
 
-Building it locally has to happen on arm64 — cross-building the CUDA extensions
-under QEMU takes hours. As with the x86 image, gsplat comes from a separate
-build context so the build doesn't have to send `data/`:
+<details>
+<summary>Building it locally</summary>
+
+The submodules have to be checked out and passed in as extra build contexts, so
+the build doesn't have to send `data/`:
 
 ```
-git submodule update --init third_party/gsplat
-docker build -f artifacts/docker/jetson.dockerfile -t gaussiansplatting-jetson:dev \
+git submodule update --init third_party/gsplat third_party/colmap
+docker build -f artifacts/docker/dev.dockerfile -t easygaussiansplatting:dev \
   --build-context gsplatsrc=./third_party/gsplat \
-  --build-context colmapsrc=./third_party/colmap \
-  --build-context reposrc=. artifacts/docker
+  --build-context colmapsrc=./third_party/colmap artifacts/docker
 ```
 
-For a direct install, initialize the submodule and run the shared installer from the checkout:
+Point `DOCKER_IMAGE` at the local tag to run it instead of the published one.
+
+</details>
+
+## Generating the proto bindings
+
+`gsplat_pb2.py` and `gsplat_pb2_grpc.py` are gitignored, and the image ships
+`grpcio` but no `protoc`, so generate them in the checkout before the first
+start:
 
 ```
-git submodule update --init third_party/gsplat
-GSPLAT_DIR="$PWD/third_party/gsplat" bash artifacts/docker/installers/install_gsplat.sh
+bash gsplat_server/proto/build.sh
 ```
 
-This avoids Docker startup overhead, but Docker keeps the CUDA/Python environment reproducible and is easier to roll back.
+Rerun it whenever `proto/gsplat.proto` changes, on both the server host and any
+client machine.
 
-Two pins are worth knowing about. The image builds COLMAP from the checked-out submodule with CUDA disabled; CUDA remains available to gsplat through JetPack. `install_gsplat.sh` fetches torch,
-torchvision, and pycolmap as direct wheel URLs from NVIDIA's Jetson index,
-because PyPI's aarch64 wheels are server-Grace builds that won't run on an Orin
-(and it has no aarch64 pycolmap at all). And the CUDA extensions are compiled
-for compute capability 8.7 only, which is the Orin's — the image will not run on
-another GPU.
+<details>
+<summary>Verifying GPU access</summary>
+
+```
+docker run --rm --gpus all ghcr.io/mapmindai/gaussiansplatting:latest \
+  conda run --no-capture-output -n gsplat python3 -c \
+  "import torch, gsplat; print(torch.__version__, torch.cuda.is_available(), torch.cuda.get_device_name(0))"
+```
+
+The output must include `True` and the GPU's name. A missing driver or
+Container Toolkit instead ends in `RuntimeError: No CUDA GPUs are available`,
+which is also how jobs would fail.
+
+</details>
 
 ## Running the server
 
-On the Orin, from a checkout of this repo:
+From the checkout:
 
 ```
 gsplat_server/run_server.sh [port] [jobs_dir]
 ```
 
-`port` defaults to 50051 and `jobs_dir` to `data/gsplat_server`, relative to the
-checkout, which is where uploads, logs, and trained models land. The script runs
-in the foreground; wrap it in a systemd unit to start it at boot. It passes
-`--runtime nvidia`, which is how JetPack exposes the GPU; override
-`DOCKER_GPU_FLAGS` if your daemon is configured for `--gpus all` instead.
+`port` defaults to 50051 and `jobs_dir` to `data/gsplat_server`, which is where
+uploads, logs, and trained models land. Under Docker `jobs_dir` has to live
+under the checkout, because that is what the container sees. The script runs in
+the foreground; to start it at boot, wrap it in a systemd unit:
+
+```
+[Unit]
+Description=gsplat training server
+After=docker.service
+Requires=docker.service
+
+[Service]
+WorkingDirectory=/srv/EasyGaussianSplatting
+ExecStart=/srv/EasyGaussianSplatting/gsplat_server/run_server.sh 50051 data/gsplat_server
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+The unit runs as root, which is also how the container runs, so everything
+under `jobs_dir` is root-owned; a `User=` needs `docker` group membership.
+
+`run_server.sh` passes `--gpus all` (override `DOCKER_GPU_FLAGS`) and
+`--shm-size=8g`. The shared memory matters: below roughly 8g the trainer's
+dataloader workers die partway through a run with a bus error, which surfaces
+as a failed job whose log ends in `DataLoader worker ... killed by signal: Bus
+error`.
 
 Jobs run one at a time — a single training run already saturates the GPU — and
 the queue lives in memory, so a restart fails whatever was queued or training.
@@ -76,7 +126,7 @@ Finished jobs survive it.
 downloads the point cloud. The client requires Python 3 and `grpcio` and loads
 `gsplat_server/config/gsplat_train_defaults.proto.txt` for training parameters:
 ```
-gsplat_server/client.py data/pano_mapping_cubemap --server orin:50051 \
+gsplat_server/client.py data/pano_mapping_cubemap --server gsplat-host:50051 \
   --output pano.ply
 ```
 Pass `--parameters` with another text-format JobParameters file for a custom
@@ -96,7 +146,8 @@ by `grow_grad2d`, `prune_opa`, `reset_every` and `absgrad`. It is harder to
 operate: `prune_opa` also sets the opacity reset floor (gsplat resets to
 `prune_opa * 2`), so lowering it does not simply prune less -- combined with
 `reset_every` it can collapse a model to a few thousand Gaussians. See
-`doc/gsplat_parameter_sweep.md` for measured comparisons.
+[doc/gsplat_parameter_sweep.md](gsplat_parameter_sweep.md) for measured
+comparisons.
 
 The directory must hold `images/` and `sparse/`; a `masks/` directory is
 uploaded too if present, and training then skips the masked pixels (see
@@ -114,6 +165,13 @@ run_segmentation: true
 An uploaded `masks/` always wins, so the flag is a fallback rather than an
 override. Segmentation runs on the server's GPU and adds a few minutes, plus a
 one-off download of the Mask R-CNN weights on the first such job.
+
+## Other hosts
+
+* [doc/gsplat_server_orin.md](gsplat_server_orin.md) — Jetson AGX Orin: the
+  arm64 image, `--runtime nvidia`, and a direct install without Docker.
+* [doc/gsplat_server_wins.md](gsplat_server_wins.md) — Windows: the same x86
+  image under Docker Desktop, with the checkout on `D:`.
 
 ## gRPC API
 

--- a/doc/gsplat_server_orin.md
+++ b/doc/gsplat_server_orin.md
@@ -1,10 +1,78 @@
-# Direct gsplat installation on an AGX Orin
+# Gaussian Splatting server on a Jetson AGX Orin
+
+The same gRPC service as [doc/gsplat_server.md](gsplat_server.md), run on an
+Orin. That doc covers the service itself — the client, the training parameters,
+and the gRPC API; only the Orin-specific parts are here.
+
+## Docker deployment
+
+CI builds only the x86 image. Build the arm64 one on an Orin as below, or pull
+it if it has already been pushed:
+
+```
+docker pull ghcr.io/mapmindai/gaussiansplatting-jetson:latest
+```
+
+It is JetPack 6 (L4T r36.4, CUDA 12.6) with gsplat installed into the system
+Python rather than a conda env, plus COLMAP for inspection and repair.
+`--runtime nvidia` is how JetPack exposes the GPU, rather than the `--gpus all`
+the host scripts default to:
+
+```
+DOCKER_IMAGE=ghcr.io/mapmindai/gaussiansplatting-jetson:latest \
+  DOCKER_GPU_FLAGS="--runtime nvidia" gsplat_server/run_server.sh [port] [jobs_dir]
+```
+
+Generate the proto bindings in the checkout first, and see
+[doc/gsplat_server.md](gsplat_server.md) for the arguments and the systemd
+unit.
+
+<details>
+<summary>Building the image locally</summary>
+
+Build on arm64 — cross-building the CUDA extensions under QEMU takes hours. The
+submodules come in as extra build contexts so the build doesn't have to send
+`data/`:
+
+```
+git submodule update --init third_party/gsplat third_party/colmap
+docker build -f artifacts/docker/jetson.dockerfile -t gaussiansplatting-jetson:dev \
+  --build-context gsplatsrc=./third_party/gsplat \
+  --build-context colmapsrc=./third_party/colmap \
+  --build-context reposrc=. artifacts/docker
+```
+
+`install_gsplat_orin.sh` fetches torch,
+torchvision, and pycolmap as direct wheel URLs from NVIDIA's Jetson index,
+because PyPI's aarch64 wheels are server-Grace builds that won't run on an Orin
+(and it has no aarch64 pycolmap at all). And the CUDA extensions are compiled
+for compute capability 8.7 only, which is the Orin's — this image will not run
+on another GPU. COLMAP is built from the checked-out submodule with CUDA
+disabled; CUDA stays available to gsplat through JetPack.
+
+</details>
+
+<details>
+<summary>Verifying GPU access</summary>
+
+```
+docker run --rm --runtime nvidia ghcr.io/mapmindai/gaussiansplatting-jetson:latest \
+  python3 -c \
+  "import torch, gsplat; print(torch.__version__, torch.version.cuda, torch.cuda.get_device_name(0))"
+```
+
+The output must include CUDA `12.6` and `Orin`. An image built for another
+board fails here with `no kernel image is available for execution`.
+
+</details>
+
+## Direct installation
 
 This runbook records the direct installation tested on a Jetson AGX Orin running
 JetPack 6 / L4T r36.5 and CUDA 12.6. It installs the training environment into
 the user's Python environment; it does not install COLMAP.
 
-## 1. Prepare the Orin
+### 1. Prepare the Orin
 
 Install the CUDA compiler and development headers. The runtime included with
 JetPack is not enough to compile gsplat's PyTorch extension:
@@ -23,7 +91,7 @@ export PATH=/usr/local/cuda/bin:$HOME/.local/bin:$PATH
 nvcc --version
 ```
 
-## 2. Copy the checkout
+### 2. Copy the checkout
 
 The Orin needs the repository, the gsplat submodule, and the training scripts.
 From the development machine:
@@ -41,7 +109,7 @@ cd /home/dm/Development/EasyGaussianSplatting
 export GSPLAT_DIR="$PWD/third_party/gsplat"
 ```
 
-## 3. Install Python and CUDA dependencies
+### 3. Install Python and CUDA dependencies
 
 The Orin uses NVIDIA's Jetson wheels. PyPI's aarch64 PyTorch wheels target
 server Grace systems and are not suitable for Jetson.
@@ -68,7 +136,7 @@ visible when running Python:
 export LD_LIBRARY_PATH="$HOME/.local/lib/python3.10/site-packages/nvidia/cu12/lib:$HOME/.local/lib/python3.10/site-packages/nvidia/cublas/lib:$HOME/.local/lib/python3.10/site-packages/nvidia/cuda_nvrtc/lib:${LD_LIBRARY_PATH:-}"
 ```
 
-## 4. Build gsplat for Orin
+### 4. Build gsplat for Orin
 
 The extension must be compiled for the AGX Orin's `sm_87` architecture. The
 installer sets this automatically. The build is CPU-intensive and can take a
@@ -98,7 +166,7 @@ python3 -c 'import torch, gsplat; print(torch.__version__, torch.version.cuda); 
 
 Expected output includes PyTorch `2.9.1`, CUDA `12.6`, and `Orin`.
 
-## 5. Install server dependencies
+### 5. Install server dependencies
 
 Install the dependencies used by the gRPC server and the supported gsplat
 examples. The Orin installer omits optional packages without a Jetson wheel.
@@ -111,7 +179,7 @@ python3 -m pip install --user --no-cache-dir --no-build-isolation \
   -r /tmp/gsplat-requirements.txt grpcio
 ```
 
-## 6. Start and test the server
+### 6. Start and test the server
 
 The direct installation runs the server with Python rather than Docker. Keep
 the CUDA library variables in the same shell used to start it:
@@ -146,7 +214,7 @@ The client loads training parameters from gsplat_server/config/gsplat_train_defa
 The server queue is in memory, while uploaded jobs, logs, and results are kept
 under the jobs directory.
 
-## Notes
+### Notes
 
 - The direct path installs the training side only. Run COLMAP on the client or
   install it separately on the Orin before attempting a full reconstruction.

--- a/doc/gsplat_server_wins.md
+++ b/doc/gsplat_server_wins.md
@@ -2,7 +2,9 @@
 
 This guide runs the x86 gsplat image in Docker Desktop on a Windows PC with an
 NVIDIA GPU. The project is stored on `D:` and the server exposes gRPC on port
-`50051`.
+`50051`. [doc/gsplat_server.md](gsplat_server.md) covers the service itself —
+the client, the training parameters, and the gRPC API; only the
+Windows-specific parts are here.
 
 ## Prerequisites
 
@@ -58,8 +60,9 @@ The expected result includes `True` and the NVIDIA GPU name.
 
 ## Start the server
 
-`run_server.sh` activates the image's conda environment, points the trainer at
-the installed gsplat, and sets a shared-memory size the dataloader survives.
+`run_server.sh` sets the GPU flags and a shared-memory size the dataloader
+survives; `serve.sh` activates the image's conda environment and points the
+trainer at the installed gsplat.
 Run it from the checkout on `D:`:
 
 ```
@@ -133,4 +136,4 @@ docker stop gsplat-server
 docker start gsplat-server
 ```
 
-Jobs and results remain under `D:\EasyGaussianSplatting\gsplat_jobs`.
+Jobs and results remain under `D:\EasyGaussianSplatting\data\gsplat_server`.


### PR DESCRIPTION
## What

`doc/gsplat_server.md` was written for a Jetson AGX Orin, so the default deployment — an x86_64 Linux host running the image CI publishes — had no guide, and the doc's `--runtime nvidia` advice was wrong for it (`scripts/docker_common.sh` defaults to `--gpus all`).

- **`doc/gsplat_server.md`** is now the Linux (x86_64) guide: prerequisites, generating the proto bindings, running the server with a systemd unit, and the `--shm-size=8g` floor the dataloader needs. Building the image locally and verifying GPU access are collapsed into `<details>`, being one-offs.
- **`doc/gsplat_server_orin.md`** gains a Docker deployment section above the direct-install runbook that was already there (that runbook is unchanged apart from heading levels).
- **`doc/gsplat_server_wins.md`** gains a backlink and two factual fixes.
- **`README.md`**: the section pointing here was titled "Training on a Jetson AGX Orin"; it now covers all three hosts, and the stale status checkbox is updated.

## Verified against the code, not assumed

- The image ships `grpcio` 1.83 but **no** `protoc`/`grpc_python_plugin`, and `gsplat_server/proto/*_pb2*.py` are gitignored — so the bindings must be generated in the checkout before the first start. This step was missing from the docs and is a first-run blocker.
- Ran the documented GPU check on this host: `2.9.1+cu128 True NVIDIA GeForce GTX 1650 Ti`. Ran it again without a GPU to confirm the documented failure text: `RuntimeError: No CUDA GPUs are available`.
- `run_server.sh` defaults (`50051`, `data/gsplat_server`) and the must-live-under-the-checkout rule enforced by `repo_relative_path()`.

## Corrections to pre-existing text

- The Orin guide no longer claims CI publishes the arm64 image — `.github/workflows/docker.yml` has one job, which builds `dev.dockerfile` and pushes `gaussiansplatting` only. There is no jetson job.
- The Windows guide attributed conda activation to `run_server.sh`; it happens in `scripts/gsplat_env.sh`, sourced by `serve.sh`. It also pointed at a `gsplat_jobs` directory that appears in no script or config.
- Dropped a paragraph claiming `GSPLAT_DIR=... bash installers/install_gsplat.sh` does a direct x86 install — that script hardcodes `/opt/gsplat`.

## /simplify

Run per CLAUDE.md §3, as two reviewers (duplication/reuse and concision/accuracy) rather than four, since the diff is prose — the efficiency angle has no purchase on Markdown. Applied: the two factual errors above, the impossible failure mode in the Orin GPU check, a `User=gsplat` systemd example that would have failed on the Docker socket without `docker` group membership, qualifying the `jobs_dir` rule as Docker-only (the direct install has no bind mount), path prefixes on the two table rows that live under `artifacts/docker/`, and several restated-heading and hedge cuts.

Skipped, with reasons:

- **Trimming the duplicated GPU check, shm-size paragraph, and client/`--parameters` walkthrough out of the Windows and Orin guides.** Correctly flagged as duplication now that both defer to the Linux doc, but the fix deletes prose I didn't write in guides that are otherwise out of this diff's scope. Worth a follow-up.
- **systemd hardening** — no `--name`/`ExecStop`, so a SIGKILLed CLI can leave a container holding the port, and `serve.sh` doesn't `exec` python3 so stops wait out the grace period. The second needs a code change; both are beyond a doc PR.
- **"CI publishes it on every push to `master`"** for the x86 image is technically path-filtered (`artifacts/**`, the submodules) and also runs on PRs. Pre-existing wording, accurate enough for the reader's purpose.

## Note

`third_party/gsplat` has four locally modified CUDA sources in the working tree. Unrelated to this change and deliberately left out of the commit.