### PR TITLE
Level the map to gravity, and detect features at 960 pixels

### DIFF
--- a/doc/gsplat_server_wins.md
+++ b/doc/gsplat_server_wins.md
@@ -1,18 +1,20 @@
 # Gaussian Splatting server on Windows Docker Desktop
 
-This guide runs the x86 gsplat image in Docker Desktop on a Windows PC with an
-NVIDIA GPU. The project is stored on `D:` and the server exposes gRPC on port
-`50051`. [doc/gsplat_server.md](gsplat_server.md) covers the service itself —
-the client, the training parameters, and the gRPC API; only the
-Windows-specific parts are here.
+This guide runs the x86 images in Docker Desktop on a Windows PC with an NVIDIA
+GPU: the Triton inference server the mapping pipeline needs, the mapping
+pipeline itself, and the gsplat training server on port `50051`. The project is
+stored on `D:`. [doc/gsplat_server.md](gsplat_server.md) covers the training
+service and [doc/panorama_mapping.md](panorama_mapping.md) the mapping stages;
+only the Windows-specific parts are here.
 
 ## Prerequisites
 
 - Windows 11 with Docker Desktop using the `desktop-linux` context.
 - NVIDIA driver with Docker GPU support.
 - SSH access to the Windows host, for example `dm@192.168.11.194`.
-- A checkout containing `gsplat_server/`, `mapping/`, and the generated proto
-  bindings.
+- A checkout containing `gsplat_server/`, `mapping/`, the generated proto
+  bindings, and — for the mapping pipeline — the `third_party/EasyTensorRT`
+  submodule, which carries the models and is around 800 MB.
 
 The Jetson image is ARM64 and must not be used on this PC. Use the x86 image:
 
@@ -21,6 +23,14 @@ ghcr.io/mapmindai/gaussiansplatting:latest
 ```
 
 ## Copy the project to `D:`
+
+Generate the ignored Python protobuf bindings and check out the models first;
+neither is in a fresh clone, and the archive below has to carry both:
+
+```
+bash gsplat_server/proto/build.sh
+git submodule update --init third_party/EasyTensorRT
+```
 
 Create an archive without local datasets or Git history, copy it to the host,
 and extract it to `D:\EasyGaussianSplatting`:
@@ -39,12 +49,6 @@ tar -xf C:\Users\49451\easy-gsplat-server.tar.gz \
   -C D:\EasyGaussianSplatting
 ```
 
-Generate the ignored Python protobuf bindings before creating the archive:
-
-```
-bash gsplat_server/proto/build.sh
-```
-
 ## Verify Docker GPU access
 
 Select Docker Desktop's Linux engine and run:
@@ -58,7 +62,56 @@ docker run --rm --gpus all ghcr.io/mapmindai/gaussiansplatting:latest \
 
 The expected result includes `True` and the NVIDIA GPU name.
 
-## Start the server
+## Start the TensorRT inference server
+
+The mapping pipeline extracts and matches learned features against a Triton
+server, which serves them out of `third_party/EasyTensorRT`. Start it first:
+
+```
+docker run -d --name tritonserver_trt --gpus all -p 8011:8001 \
+  -v D:\EasyGaussianSplatting\third_party\EasyTensorRT:/repo \
+  ghcr.io/mapmindai/tritonserver_amd64:latest \
+  bash -c "bash /repo/model_trt/convert_models.sh && tritonserver --model-repository=/repo/model_repository_trt"
+```
+
+`convert_models.sh` builds a TensorRT plan per model for this GPU into
+`model_repository_trt/<model>/1/`, so the first start takes several minutes and
+is not listening until it finishes; later starts reuse the plans. Follow it
+with `docker logs -f tritonserver_trt` and wait for:
+
+```
+Started GRPCInferenceService at 0.0.0.0:8001
+```
+
+Triton's own gRPC port is 8001, published here as 8011 because 8001 is so often
+already taken; 8011 is what this repo defaults to.
+
+Serving the ONNX models instead skips the plan build and runs slower: point
+`--model-repository` at `/repo/model_repository` and leave out the conversion
+step.
+
+## Reconstruct a capture
+
+With the inference server up, turn a stitched panorama video into the cube-map
+model the trainer takes. `data/` is excluded from the archive above, so copy the
+video to `D:\EasyGaussianSplatting\data\` first:
+
+```
+docker run --rm --gpus all -v D:\EasyGaussianSplatting:/workspace -w /workspace \
+  ghcr.io/mapmindai/gaussiansplatting:latest \
+  python3 -m mapping.mapping_pipeline \
+    --video_path data/pano.mp4 --workspace_path data/pano_mapping \
+    --triton-url host.docker.internal:8011
+```
+
+Docker Desktop maps `host.docker.internal` to the host itself, so unlike on
+Linux no `--add-host` is needed. That is the only Windows-specific part;
+[panorama_mapping.md](panorama_mapping.md) covers the stages and the options.
+
+The workspace it writes — `images/<face>/`, `database.db`, `sparse/0/` — is what
+the training service below takes.
+
+## Start the training server
 
 `run_server.sh` sets the GPU flags and a shared-memory size the dataloader
 survives; `serve.sh` activates the image's conda environment and points the

--- a/doc/panorama_mapping.md
+++ b/doc/panorama_mapping.md
@@ -17,8 +17,10 @@ global SfM (GLOMAP):
    COLMAP types its descriptors table `uint8`, so the float descriptors are
    stored byte-reinterpreted under a learned-extractor tag. That is lossless
    and the mapper never reads the tag, but COLMAP's own matchers dispatch on
-   it: this database is for this pipeline, not for `colmap matcher`. Each image
-   keeps its 512 strongest detections, LightGlue's exported input size.
+   it: this database is for this pipeline, not for `colmap matcher`. Detection
+   runs on the face downscaled to 960 pixels and the keypoints are scaled back,
+   so `--face-size` sets the stored resolution rather than the detector's. Each
+   image keeps its 512 strongest detections, LightGlue's exported input size.
 3. **Matching** — LightGlue over two sets of candidate pairs: each image
    against the next `--num-sequential` images of the same cube face, and
    against its `--num-retrieval` nearest images by SALAD descriptor. Retrieval
@@ -29,7 +31,11 @@ global SfM (GLOMAP):
    a match, is what ties them together.
 4. **Global mapping** — `pycolmap.global_mapping` into `sparse/0/`. The cube
    faces' intrinsics and rig mounting come from the reprojection rather than a
-   calibration, so bundle adjustment holds both fixed.
+   calibration, so bundle adjustment holds both fixed. The solved map is then
+   rotated so `+Z` is up: global SfM fixes the world frame on whichever image it
+   starts from, but the rig is carried upright, so its own down axis is gravity
+   and averaging that over the registered frames says which way the map leans.
+   It is a rotation about the origin, so positions and scale are untouched.
 
 A re-run picks up where the last one stopped: the database is kept once it
 holds images, extraction is skipped once the sidecar is written, matching skips
@@ -70,21 +76,20 @@ configuration. Point `TRITON_URL` at `host:port` to use a server elsewhere.
 ```
 docker run -it --rm --gpus all -v $(pwd):/workspace -w /workspace \
   --add-host host.docker.internal:host-gateway \
-  ghcr.io/mapmindai/gaussiansplatting:latest \
+  easygaussiansplatting:triton \
   python3 -m mapping.mapping_pipeline \
-    --video_path data/VID_20260422_153814_00_004_pano.mp4 \
-    --workspace_path data/VID_20260422_153814_00_004_reconstruction \
-    --triton-url host.docker.internal:8011
+    --video_path data/VID_20260902_113042_00_006_pano.mp4 \
+    --workspace_path data/VID_20260902_113042_00_006_reconstruction \
+    --triton-url 192.168.11.194:8011 --num-threads 4
 ```
 
 `--video_path` is the stitched video and `--workspace_path` the directory to
 reconstruct into; both are required.
 `--frame-rate` (frames/sec sampled from the video) defaults to 2, `--face-size`
 (cube-face width/height in pixels) to a quarter of the video width — which
-keeps the panorama's angular resolution — and `--faces` to
-`front,right,back,left,up` — the nadir usually shows whoever is carrying the
-rig, so pass all six explicitly to include it. The face list must contain
-`front`, the rig's reference sensor. `--num-sequential`, `--num-retrieval`, and
+keeps the panorama's angular resolution — and `--faces` to all six. Drop `down`
+to leave out the nadir, which mostly shows whoever is carrying the rig. The face
+list must contain `front`, the rig's reference sensor. `--num-sequential`, `--num-retrieval`, and
 `--num-retrieval-excluded` tune pair selection; `--help` lists everything.
 
 The workspace ends up holding `images/<face>/`, `database.db`,

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -43,8 +43,8 @@ server serving those models — see
 [panorama_mapping.md](panorama_mapping.md), which also covers each stage and
 the pair-selection knobs. `--frame-rate` (frames/sec sampled from the video)
 defaults to 2, `--face-size` to a quarter of the video width, and `--faces` to
-`front,right,back,left,up` since the nadir usually shows whoever is carrying
-the rig — pass all six explicitly to include it:
+all six; drop `down` to leave out the nadir, which mostly shows whoever is
+carrying the rig:
 
 ```
 python3 -m mapping.mapping_pipeline \

--- a/mapping/features/extraction.py
+++ b/mapping/features/extraction.py
@@ -33,14 +33,6 @@ def _keypoints_blob(keypoints):
     return blob
 
 
-def largest_camera_size(database):
-    """The largest camera dimension in the database, which the local extractor
-    takes as its input size so that no image is downscaled before detection."""
-    return max(
-        max(camera.width, camera.height) for camera in database.read_all_cameras()
-    )
-
-
 def extract_features(workspace_path, local_extractor, global_extractor, num_threads=8):
     """Extracts features for every image in `<workspace_path>/database.db`.
 

--- a/mapping/features/triton_models.py
+++ b/mapping/features/triton_models.py
@@ -38,6 +38,13 @@ from superpoint import SuperPoint  # noqa: E402
 # re-extracting.
 MATCHER_NUM_KEYPOINTS = 512
 
+# Longest side SuperPoint detects on. A larger image is downscaled to it and
+# its keypoints scaled back, so a cube face of any size still lands in
+# full-resolution coordinates. It is the size the TensorRT plan is built
+# around, and detecting on a 2000-pixel face instead costs several times the
+# GPU memory for detections the 512-point matcher input cannot carry anyway.
+DETECTOR_MAX_IMAGE_SIZE = 960
+
 
 @dataclass
 class LocalFeatures:
@@ -55,12 +62,11 @@ def _without_batch_axis(array, ndim):
 class LocalFeatureExtractor:
     """SuperPoint keypoints and descriptors."""
 
-    def __init__(self, triton_url, max_image_size, keypoint_threshold=0.015,
-                 model_version="1"):
+    def __init__(self, triton_url, keypoint_threshold=0.015, model_version="1"):
         self._client = SuperPoint(
             triton_url,
             model_version=model_version,
-            max_image_shape=max_image_size,
+            max_image_shape=DETECTOR_MAX_IMAGE_SIZE,
             keypoint_thresh=keypoint_threshold,
         )
 

--- a/mapping/mapping_pipeline.py
+++ b/mapping/mapping_pipeline.py
@@ -14,21 +14,24 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import numpy as np
 import pycolmap
 from pycolmap import logging
 
-from .features.extraction import (
-    GLOBAL_FEATURES_FILENAME,
-    extract_features,
-    largest_camera_size,
-)
+from .features.extraction import GLOBAL_FEATURES_FILENAME, extract_features
 from .features.matching import PairSelection, match_features
 from .features.triton_models import (
     FeatureMatcher,
     GlobalFeatureExtractor,
     LocalFeatureExtractor,
 )
-from .panorama_database import DEFAULT_FACES, FACE_AXES, build_database, parse_faces
+from .panorama_database import (
+    DEFAULT_FACES,
+    FACE_AXES,
+    RIG_DOWN,
+    build_database,
+    parse_faces,
+)
 
 
 # Weight each relative-rotation edge by its inlier match count instead of
@@ -60,6 +63,45 @@ def build_global_mapper_options():
     return options
 
 
+_WORLD_DOWN = np.array([0.0, 0.0, -1.0])
+# Half a turn about X, for a map solved upside down: the shortest arc has no
+# determined axis there, and every horizontal one serves equally.
+_HALF_TURN = pycolmap.Rotation3d(np.array([1.0, 0.0, 0.0, 0.0]))
+
+
+def _rotation_to_world_down(down):
+    """The shortest-arc rotation taking the unit vector `down` onto -Z."""
+    cosine = float(np.dot(down, _WORLD_DOWN))
+    if cosine < -1.0 + 1e-9:
+        return _HALF_TURN
+    quaternion = np.array([*np.cross(down, _WORLD_DOWN), 1.0 + cosine])
+    return pycolmap.Rotation3d(quaternion / np.linalg.norm(quaternion))
+
+
+def align_up_axis(reconstruction):
+    """Rotates `reconstruction` in place so that +Z points up.
+
+    Global SfM fixes the world frame on whichever image it starts from, leaving
+    the map tilted arbitrarily. Every panorama here is captured upright, so the
+    rig's own down axis is gravity: averaging it over the registered frames
+    gives gravity in world axes, and one rotation takes that to -Z. Over a real
+    capture that axis holds to half a degree per frame, which is what makes the
+    average meaningful. Positions and scale are left as the mapper solved them.
+    """
+    down = np.zeros(3)
+    for frame in reconstruction.frames.values():
+        if frame.has_pose:
+            down += frame.rig_from_world.rotation.inverse() * RIG_DOWN
+    if np.linalg.norm(down) < 1e-9:
+        logging.warning("No registered frames to read gravity from, leaving the map as solved")
+        return
+    down /= np.linalg.norm(down)
+    reconstruction.transform(
+        pycolmap.Sim3d(1.0, _rotation_to_world_down(down), np.zeros(3))
+    )
+    logging.info(f"Rotated {np.round(down, 3)} to -Z, so the map is +Z up")
+
+
 def run_global_mapping(workspace_path):
     """Reconstructs `<workspace_path>/database.db` into `sparse/`."""
     workspace_path = Path(workspace_path)
@@ -74,6 +116,9 @@ def run_global_mapping(workspace_path):
     if not reconstructions:
         raise RuntimeError("Global mapping produced no reconstruction")
     for index, model in sorted(reconstructions.items()):
+        align_up_axis(model)
+        # Rewritten over what global_mapping just wrote, which is the untilted map.
+        model.write(sparse_dir / str(index))
         logging.info(
             f"Wrote {sparse_dir / str(index)}: {model.num_reg_images()} images, "
             f"{model.num_points3D()} points"
@@ -93,11 +138,9 @@ def run_pipeline(video_path, workspace_path, triton_url, selection, frame_rate=2
     if (workspace_path / GLOBAL_FEATURES_FILENAME).exists():
         logging.info("Global-descriptor sidecar already exists, skipping extraction")
     else:
-        with pycolmap.Database.open(workspace_path / "database.db") as database:
-            max_image_size = largest_camera_size(database)
         extract_features(
             workspace_path,
-            LocalFeatureExtractor(triton_url, max_image_size, keypoint_threshold),
+            LocalFeatureExtractor(triton_url, keypoint_threshold),
             GlobalFeatureExtractor(triton_url),
             num_threads,
         )

--- a/mapping/panorama_database.py
+++ b/mapping/panorama_database.py
@@ -29,9 +29,10 @@ FACE_AXES = {
     "down": ((0, -1, 0), (0, 0, 1), (-1, 0, 0)),
 }
 
-# The nadir points at the ground below the rig, where whoever is carrying it
-# usually shows up, so it is left out unless asked for explicitly.
-DEFAULT_FACES = ("front", "right", "back", "left", "up")
+# Every face. The nadir shows whoever is carrying the rig, which person masking
+# takes out of training, and the ground it also sees is texture the mapper can
+# match on.
+DEFAULT_FACES = ("front", "right", "back", "left", "up", "down")
 
 # The rig's reference sensor: every other face's sensor_from_rig is expressed
 # relative to this one.
@@ -50,6 +51,12 @@ def face_rotation(face):
     # The inverse (transpose, since orthonormal) of face_to_equirect_matrix
     # rotates equirect-camera-frame vectors into this face's camera frame.
     return face_to_equirect_matrix(face).T
+
+
+# Gravity in the rig frame, which is the reference face's camera frame. The
+# panorama's own axes put +Y up, so rotating its down axis into that face gives
+# the direction an upright capture falls in -- whichever face is the reference.
+RIG_DOWN = face_rotation(REFERENCE_FACE) @ np.array([0.0, -1.0, 0.0])
 
 
 def sensor_from_rig(face):

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -40,7 +40,7 @@ docker run -i "${DOCKER_RUN_FLAGS[@]}" \
   -e FACE_SIZE="${FACE_SIZE}" \
   -e TRITON_URL="${TRITON_URL}" \
   -e PARAMETERS_FILE="/workspace/${REL_PARAMETERS_FILE}" \
-  -e MODEL_ROOT_DIR="${MODEL_ROOT_DIR:-/EasyGaussianSplatting/data/sdk_dir}" \
+  -e MODEL_ROOT_DIR="${MODEL_ROOT_DIR:-}" \
   "${DOCKER_IMAGE}" bash -s <<'CONTAINER'
 set -euo pipefail
 
@@ -48,7 +48,7 @@ set -euo pipefail
 export PYTHONPATH="${PWD}${PYTHONPATH:+:${PYTHONPATH}}"
 
 # --- 1. Stitch the capture into an equirectangular video --------------------
-bash scripts/stitch_video.sh
+bash scripts/stitch_video.sh "${INPUT_INSV}" "${OUTPUT_VIDEO}" "${OUTPUT_SIZE}"
 
 # --- 2. Reconstruct it as a cube-map rig ------------------------------------
 MAPPING_ARGUMENTS=(--triton-url "${TRITON_URL}")
@@ -65,8 +65,7 @@ python3 -m mapping.mapping_pipeline \
 source scripts/gsplat_env.sh
 
 python3 mapping/segment_people.py \
-  "${RECONSTRUCTION_DIR}/images" "${RECONSTRUCTION_DIR}/masks" \
-  --score-threshold 0.5 --dilation 8
+  "${RECONSTRUCTION_DIR}/images" "${RECONSTRUCTION_DIR}/masks"
 
 export PYTORCH_ALLOC_CONF="${PYTORCH_ALLOC_CONF:-expandable_segments:True}"
 python3 mapping/train_gsplat_with_masks.py default \

--- a/scripts/run_stitch.sh
+++ b/scripts/run_stitch.sh
@@ -19,11 +19,8 @@ OUTPUT_SIZE="${3:-8000x4000}"
 mkdir -p "$(dirname "${OUTPUT_VIDEO}")"
 REL_OUTPUT_VIDEO="$(repo_relative_path "${OUTPUT_VIDEO}")"
 
-docker run -i "${DOCKER_RUN_FLAGS[@]}" \
-  -e INPUT_INSV="/workspace/${REL_INSV}" \
-  -e OUTPUT_VIDEO="/workspace/${REL_OUTPUT_VIDEO}" \
-  -e OUTPUT_SIZE="${OUTPUT_SIZE}" \
-  -e MODEL_ROOT_DIR="${MODEL_ROOT_DIR:-/EasyGaussianSplatting/data/sdk_dir}" \
-  "${DOCKER_IMAGE}" bash scripts/stitch_video.sh
+docker run "${DOCKER_RUN_FLAGS[@]}" -e MODEL_ROOT_DIR="${MODEL_ROOT_DIR:-}" \
+  "${DOCKER_IMAGE}" bash scripts/stitch_video.sh \
+  "/workspace/${REL_INSV}" "/workspace/${REL_OUTPUT_VIDEO}" "${OUTPUT_SIZE}"
 
 echo "Stitched video written to ${REPO_ROOT}/${REL_OUTPUT_VIDEO}"

--- a/scripts/stitch_video.sh
+++ b/scripts/stitch_video.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 # Stitch an Insta360 capture into an equirectangular video with the AI-stitch
-# settings we reconstruct from. Runs inside the container; scripts/run_stitch.sh
-# and scripts/run_pipeline.sh drive it. Reads INPUT_INSV, OUTPUT_VIDEO,
-# OUTPUT_SIZE, and MODEL_ROOT_DIR from the environment.
+# settings we reconstruct from. Runs inside the container; scripts/run_stitch.sh,
+# scripts/run_pipeline.sh, and the pipeline server drive it.
 set -euo pipefail
+
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 <input.insv> <output.mp4> <output_size>" >&2
+  exit 1
+fi
+
+INPUT_INSV="$1"
+OUTPUT_VIDEO="$2"
+OUTPUT_SIZE="$3"
+# The only place the image's SDK path is spelled out; the host scripts forward
+# the variable empty when the caller has not set one.
+MODEL_ROOT_DIR="${MODEL_ROOT_DIR:-/EasyGaussianSplatting/data/sdk_dir}"
 
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:/usr/local/lib"
 


### PR DESCRIPTION
## Gravity alignment

Global SfM fixes the world frame on whichever image it starts from, so the
solved map leans arbitrarily. Every panorama here is captured upright, which
makes the rig's own down axis gravity: `align_up_axis()` averages it over the
registered frames and applies one `Sim3d` rotation taking that to `-Z`, so the
map comes out `+Z` up. Rotation about the origin only — positions and scale are
left as the mapper solved them.

The axis is derived in `panorama_database.py` from `FACE_AXES` and
`REFERENCE_FACE` rather than written out, so changing the face convention
cannot silently level the map about the wrong one.

Measured on a real 48-frame capture:

| | |
| --- | --- |
| rig `+y` in world, spread over 48 frames | **0.5°** — this is the gravity axis |
| rig `+x` / `+z` in world, spread | 174° — they swing with heading |
| gravity after alignment | `[0 0 -1]`, error **0.000000°** |
| camera height spread after alignment | **0.0212 m** over 11.94 m travelled |
| pairwise camera distances, point norms | preserved |
| shortest-arc rotation, 3000 random directions | worst error 2.15e-15 |

The height spread is the check worth trusting: a wrong axis would put metres
there. The upside-down degenerate case (no determined rotation axis) is covered
by a half-turn and tested.

## 960-pixel detection

SuperPoint detected at the largest camera dimension, i.e. 2000 for an 8000x4000
stitch. It now detects at 960: the client downscales to that and scales the
keypoints back, so faces still land in full-resolution coordinates. Verified
against a live server — a 2000x2000 face returns keypoints spanning 17..1979.

This is ~4.3x fewer detector pixels and gRPC payload per image, for detections
the matcher's 512-keypoint exported input cannot carry anyway, and it keeps the
input inside the shapes the TensorRT plans are built for. `largest_camera_size()`
loses its only caller and goes.

## Also

- The nadir joins the default faces. Person masking takes the operator out of
  training, and the ground it also sees is texture the mapper can match on.
  Costs ~20% more images through every per-image and per-pair stage.
- `stitch_video.sh` takes its paths as arguments instead of reading them from
  the environment, so a caller can stitch to a path it chooses. All callers
  updated. The image's SDK path is now defaulted only there.

## /simplify

Four review agents. Applied: `pycolmap`'s own rotation primitives in place of a
hand-rolled Rodrigues assembly and a `matrix().T @ v` transpose (`Rotation3d`
from an xyzw quaternion, `rotation.inverse() * v`) — verified equivalent before
adopting; the rotation helper specialised to its one fixed target, dropping a
nested degenerate-axis search; the gravity axis moved next to the convention it
depends on; one default for the SDK path instead of two; and the Windows guide
trimmed where it restated `panorama_mapping.md`.

Noted and skipped: `DETECTOR_MAX_IMAGE_SIZE` restates the submodule client's own
default, but pinning it is deliberate — the docs cite the number and a submodule
bump shouldn't move it silently. `model.write()` after alignment re-writes what
`global_mapping` just wrote; unavoidable through the pycolmap API and seconds
against an hours-long run.

Findings against the pipeline-server work still in my tree (duplicated servicer
bodies, `pipeline.proto` re-declaring messages it could import, `PYTHONPATH`
injection that belongs in `train_gsplat_with_masks.py`) are held for that PR
rather than widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
