### PR TITLE
Add a pytest suite beside each module, and run it in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,14 +5,14 @@ on:
     branches: ["master"]
     paths:
       - ".github/workflows/docker.yml"
-      - "artifacts/**"
+      - "artifacts/docker/**"
       - "third_party/gsplat"
       - "third_party/colmap"
   pull_request:
     branches: ["master"]
     paths:
       - ".github/workflows/docker.yml"
-      - "artifacts/**"
+      - "artifacts/docker/**"
       - "third_party/gsplat"
       - "third_party/colmap"
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Tests
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - ".github/workflows/tests.yml"
+      - "gsplat_server/**"
+      - "mapping/**"
+      - "conftest.py"
+      - "pytest.ini"
+      - "artifacts/requirements-test.txt"
+  pull_request:
+    branches: ["master"]
+    paths:
+      - ".github/workflows/tests.yml"
+      - "gsplat_server/**"
+      - "mapping/**"
+      - "conftest.py"
+      - "pytest.ini"
+      - "artifacts/requirements-test.txt"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    # The tests need no GPU, COLMAP, or Triton, so they run on a slim image
+    # rather than paying to pull the 20 GB pipeline one.
+    container: python:3.11-slim
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Install test dependencies
+        run: pip install --no-cache-dir -r artifacts/requirements-test.txt
+
+      # The bindings are gitignored, so the tests need them generated first.
+      # This image has no protoc, so the script uses grpcio-tools' copy.
+      - name: Generate the proto bindings
+        run: bash gsplat_server/proto/build.sh
+
+      - name: Run the tests
+        run: pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,23 +4,30 @@ Mandatory rules for AI coding agents contributing to this repo. Direct user inst
 
 ```text
 .
-├── .github/workflows/docker.yml  # Builds and publishes the Docker image.
-├── artifacts/docker/
-│   ├── dev.dockerfile            # COLMAP, Insta360 SDK, ExifTool, and gsplat.
-│   ├── jetson.dockerfile         # arm64 image: JetPack 6 CUDA and gsplat.
-│   └── installers/               # Docker image installation scripts.
+├── .github/workflows/
+│   ├── docker.yml                # Builds and publishes the Docker image.
+│   └── tests.yml                 # Runs the tests on a slim Python image.
+├── artifacts/
+│   ├── requirements-test.txt     # Test-only dependencies.
+│   └── docker/
+│       ├── dev.dockerfile        # COLMAP, Insta360 SDK, ExifTool, and gsplat.
+│       ├── jetson.dockerfile     # arm64 image: JetPack 6 CUDA and gsplat.
+│       └── installers/           # Docker image installation scripts.
 ├── data/                         # Local datasets and captures; not repo-managed (see §5).
 ├── doc/                          # Pipeline, tooling, and server guides.
 ├── gsplat_server/                # gRPC training server (see doc/gsplat_server.md).
 │   ├── server.py                 # gRPC service and job queue.
+│   ├── server_test.py            # Job store, uploads, and service preconditions.
 │   ├── serve.sh                  # Container: start the service.
 │   ├── run_server.sh             # Host: start the service via Docker.
 │   ├── client.py                 # Command-line client.
 │   ├── parameters.py             # JobParameters text-protobuf helpers.
+│   ├── parameters_test.py        # Defaults layering and round trips.
 │   ├── proto/                    # gsplat.proto and its generated bindings.
 │   └── config/                   # Shipped JobParameters defaults.
 ├── mapping/
 │   ├── benchmark/                # Parameter sweeps and their Markdown report.
+│   │   ├── summarize_gsplat_sweep_test.py # Report sections and PLY geometry.
 │   │   └── configurations/       # One JobParameters file per swept configuration.
 │   ├── features/                 # Learned features (doc/panorama_mapping.md).
 │   │   ├── triton_models.py      # SuperPoint/LightGlue/SALAD clients.
@@ -41,8 +48,13 @@ Mandatory rules for AI coding agents contributing to this repo. Direct user inst
 │   ├── gsplat/                   # gsplat submodule the training stage uses.
 │   ├── colmap/                   # COLMAP source the Jetson image builds from.
 │   └── EasyTensorRT/             # Triton server and clients for the features.
+├── conftest.py                   # Puts the repo root on sys.path for the tests.
+├── pytest.ini                    # Points pytest at the tested packages.
 └── README.md                     # Pipeline, Docker image, and usage overview.
 ```
+
+Tests sit beside the module they cover, named `<module>_test.py`, and run in
+CI on a slim Python image (see README).
 
 ## 1. Read the docs before starting a task
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Mandatory rules for AI coding agents contributing to this repo. Direct user inst
 │   │   ├── matching.py           # Pair selection and LightGlue matching.
 │   │   └── progress.py           # Thread pool with progress logging.
 │   ├── mapping_pipeline.py       # The four mapping stages end to end.
+│   ├── mapping_pipeline_test.py  # Gravity levelling of the solved map.
 │   ├── panorama_database.py      # Panorama video to a cube-map rig database.
 │   ├── segment_people.py         # Person masks for the training images.
 │   └── train_gsplat_with_masks.py # simple_trainer entrypoint; reads JobParameters.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,33 @@ gsplat_server/client.py data/pano_mapping --server gsplat-host:50051
 
 See [doc/tools.md](doc/tools.md).
 
+## Tests
+
+Each `*_test.py` sits beside the module it covers, and between them they cover
+what runs without a GPU, COLMAP, or Triton: the `JobParameters` layering
+(`gsplat_server/parameters_test.py`), the training server's job store and
+archive handling (`gsplat_server/server_test.py`), and the sweep report
+generator (`mapping/benchmark/summarize_gsplat_sweep_test.py`).
+
+CI runs them on a slim Python image rather than the 20 GB pipeline one. To do
+the same locally:
+
+```
+docker run --rm -v "$PWD":/workspace -w /workspace python:3.11-slim bash -c '
+    pip install -r artifacts/requirements-test.txt
+    bash gsplat_server/proto/build.sh
+    pytest'
+```
+
+Or on the host, with the proto bindings already generated (see
+[doc/gsplat_server.md](doc/gsplat_server.md)):
+`pip install -r artifacts/requirements-test.txt && pytest`.
+
+`mapping/train_gsplat_with_masks.py` and `mapping/segment_people.py` are
+uncovered: both import torch at module scope, and the former also runs the
+trainer at import time, so covering its flag building needs a `__main__`
+guard first.
+
 ## Reconstructing a capture
 
 `mapping/mapping_pipeline.py` reprojects the panorama frames into a rig of

--- a/README.md
+++ b/README.md
@@ -107,21 +107,23 @@ See [doc/tools.md](doc/tools.md).
 
 ```bash
 GSPLAT_HOST=192.168.11.194
+VIDEO_NAME=VID_20260904_155849_00_009
 docker run -it --rm --gpus all -v $(pwd):/workspace -w /workspace \
   --add-host host.docker.internal:host-gateway \
-  easygaussiansplatting:triton \
+  ghcr.io/mapmindai/gaussiansplatting:latest \
   python3 -m mapping.mapping_pipeline \
-    --video_path data/VID_20260902_113042_00_006_pano.mp4 \
-    --workspace_path data/VID_20260902_113042_00_006_reconstruction \
+    --video_path data/${VIDEO_NAME}_pano.mp4 \
+    --workspace_path data/${VIDEO_NAME}_reconstruction \
     --triton-url ${GSPLAT_HOST}:8011 --num-threads 4
 ```
 
 3. [Training a Gaussian Splatting model](doc/gsplat_server.md)
 
 ```bash
-WORKSACEP_PATH=
-gsplat_server/client.py data/VID_20260902_113042_00_006_reconstruction \
-  --server ${GSPLAT_HOST}:50051 --output pano.ply
+WORKSPACE_PATH=${VIDEO_NAME}_reconstruction
+gsplat_server/client.py data/${WORKSPACE_PATH} \
+  --parameters gsplat_server/config/gsplat_train_defaults.proto.txt \
+  --server ${GSPLAT_HOST}:50051 --output ${WORKSPACE_PATH}/gsplat.ply
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -100,13 +100,38 @@ gsplat_server/client.py data/pano_mapping --server gsplat-host:50051
 
 See [doc/tools.md](doc/tools.md).
 
+## Reconstructing a capture
+
+1. [Stitch to video](doc/tools.md) `scripts/run_stitch.sh data/VID_xxx.insv`
+2. [Mapping a panorama capture](doc/panorama_mapping.md) run with video.
+
+```bash
+GSPLAT_HOST=192.168.11.194
+docker run -it --rm --gpus all -v $(pwd):/workspace -w /workspace \
+  --add-host host.docker.internal:host-gateway \
+  easygaussiansplatting:triton \
+  python3 -m mapping.mapping_pipeline \
+    --video_path data/VID_20260902_113042_00_006_pano.mp4 \
+    --workspace_path data/VID_20260902_113042_00_006_reconstruction \
+    --triton-url ${GSPLAT_HOST}:8011 --num-threads 4
+```
+
+3. [Training a Gaussian Splatting model](doc/gsplat_server.md)
+
+```bash
+WORKSACEP_PATH=
+gsplat_server/client.py data/VID_20260902_113042_00_006_reconstruction \
+  --server ${GSPLAT_HOST}:50051 --output pano.ply
+```
+
 ## Tests
 
 Each `*_test.py` sits beside the module it covers, and between them they cover
 what runs without a GPU, COLMAP, or Triton: the `JobParameters` layering
 (`gsplat_server/parameters_test.py`), the training server's job store and
-archive handling (`gsplat_server/server_test.py`), and the sweep report
-generator (`mapping/benchmark/summarize_gsplat_sweep_test.py`).
+archive handling (`gsplat_server/server_test.py`), the sweep report generator
+(`mapping/benchmark/summarize_gsplat_sweep_test.py`), and the reconstruction's
+gravity levelling (`mapping/mapping_pipeline_test.py`).
 
 CI runs them on a slim Python image rather than the 20 GB pipeline one. To do
 the same locally:
@@ -126,58 +151,3 @@ Or on the host, with the proto bindings already generated (see
 uncovered: both import torch at module scope, and the former also runs the
 trainer at import time, so covering its flag building needs a `__main__`
 guard first.
-
-## Reconstructing a capture
-
-`mapping/mapping_pipeline.py` reprojects the panorama frames into a rig of
-pinhole cube faces, extracts SuperPoint and SALAD features, matches with
-LightGlue, and solves the scene with global SfM. It needs the repo checkout
-itself, for `mapping/` and the `third_party/EasyTensorRT` submodule, so mount
-the whole checkout rather than only `data/`, and it needs a Triton server
-serving those three models:
-
-```
-git submodule update --init third_party/EasyTensorRT
-```
-
-```
-docker run -it --rm -v $(pwd):/workspace -w /workspace \
-  --add-host host.docker.internal:host-gateway \
-  ghcr.io/mapmindai/gaussiansplatting:latest \
-  python3 -m mapping.mapping_pipeline \
-    --video_path data/pano.mp4 --workspace_path data/pano_mapping \
-    --triton-url host.docker.internal:8011
-```
-
-The reconstruction lands in `data/pano_mapping/` (`images/<face>/` +
-`sparse/0/`) on the host, since `/workspace` is a bind mount of your checkout.
-[doc/panorama_mapping.md](doc/panorama_mapping.md) covers serving the models,
-each stage, and the pair-selection knobs.
-
-## Training a Gaussian Splatting model
-
-The pipeline's last stage masks out people and trains a model with
-[gsplat](https://github.com/nerfstudio-project/gsplat) from the cube-map
-reconstruction. Every setting comes from the `JobParameters` file passed as
-`run_pipeline.sh`'s fifth argument: `iterations` defaults to `30000`,
-`data_factor` (a COLMAP-style downsample factor) to `1`, and
-`floater_reg_weight` (opacity/scale regularization strength) to `0.01`.
-
-The trained model lands in `<reconstruction_dir>/gsplat_output/`, including a
-final point cloud under `ply/`. The trainer also enables camera pose
-refinement, opacity/scale regularization (to suppress floaters), and
-antialiased rendering — gsplat defaults these off, but they consistently help
-on cube-map panorama captures. Export/viewer integration isn't wired yet — see
-Status.
-
-Every stage skips work already on disk, so re-running the script after a
-parameter change redoes only what is missing. To retrain alone, delete
-`gsplat_output/`.
-
-Training renders at the cube face size divided by `data_factor`, and the
-rasterizer's per-iteration buffers scale with that pixel count times the
-(growing, via densification) number of Gaussians, times one image per cube face
-per frame. On GPUs with less than ~8GB VRAM, drop `face_size` and/or raise
-`data_factor` to fit. The script also sets
-`PYTORCH_ALLOC_CONF=expandable_segments:True` to reduce allocator fragmentation
-from those buffers, which otherwise depletes VRAM before the process leaks it.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See [doc/tools.md](doc/tools.md).
 
 ## Reconstructing a capture
 
-1. [Stitch to video](doc/tools.md) `scripts/run_stitch.sh data/VID_xxx.insv`
+1. [Stitch to video](doc/tools.md) `scripts/run_stitch.sh data/${VIDEO_NAME}.insv`
 2. [Mapping a panorama capture](doc/panorama_mapping.md) run with video.
 
 ```bash

--- a/artifacts/requirements-test.txt
+++ b/artifacts/requirements-test.txt
@@ -5,5 +5,7 @@ PyYAML
 grpcio
 grpcio-tools
 numpy
+opencv-python-headless
 protobuf
+pycolmap
 pytest

--- a/artifacts/requirements-test.txt
+++ b/artifacts/requirements-test.txt
@@ -1,0 +1,9 @@
+# Dependencies for the tests, which need no GPU, COLMAP, or Triton.
+# grpcio-tools also carries the protoc that proto/build.sh falls back to.
+Pillow
+PyYAML
+grpcio
+grpcio-tools
+numpy
+protobuf
+pytest

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+"""Puts the repository root on sys.path so `gsplat_server` and `mapping` import."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))

--- a/doc/gsplat_server.md
+++ b/doc/gsplat_server.md
@@ -24,7 +24,8 @@ perspective and fisheye cameras.
 * A checkout of this repo on the host, which the container runs bind-mounted at
   `/workspace`.
 * `protoc` and the gRPC Python plugin, to generate the bindings below:
-  `sudo apt install protobuf-compiler protobuf-compiler-grpc`.
+  `sudo apt install protobuf-compiler protobuf-compiler-grpc`, or
+  `pip install grpcio-tools` for the copy it bundles.
 
 ## Getting the image
 
@@ -59,6 +60,9 @@ start:
 ```
 bash gsplat_server/proto/build.sh
 ```
+
+Without `protoc` on `PATH` the script uses the one `grpcio-tools` bundles, which
+is how CI generates them.
 
 Rerun it whenever `proto/gsplat.proto` changes, on both the server host and any
 client machine.

--- a/doc/panorama_mapping.md
+++ b/doc/panorama_mapping.md
@@ -74,13 +74,12 @@ configuration. Point `TRITON_URL` at `host:port` to use a server elsewhere.
 ## Running it
 
 ```
-docker run -it --rm --gpus all -v $(pwd):/workspace -w /workspace \
+docker run -it --rm -v $(pwd):/workspace -w /workspace \
   --add-host host.docker.internal:host-gateway \
-  easygaussiansplatting:triton \
+  ghcr.io/mapmindai/gaussiansplatting:latest \
   python3 -m mapping.mapping_pipeline \
-    --video_path data/VID_20260902_113042_00_006_pano.mp4 \
-    --workspace_path data/VID_20260902_113042_00_006_reconstruction \
-    --triton-url 192.168.11.194:8011 --num-threads 4
+    --video_path data/pano.mp4 --workspace_path data/pano_mapping \
+    --triton-url host.docker.internal:8011
 ```
 
 `--video_path` is the stitched video and `--workspace_path` the directory to

--- a/gsplat_server/parameters_test.py
+++ b/gsplat_server/parameters_test.py
@@ -1,0 +1,82 @@
+"""Tests for the JobParameters text-protobuf helpers."""
+
+import pytest
+
+from gsplat_server.parameters import (
+    load_default_parameters,
+    load_parameters,
+    parameters_from_dict,
+    parameters_to_dict,
+    parameters_to_text,
+)
+from gsplat_server.proto import gsplat_pb2
+
+
+def test_defaults_carry_the_shipped_values():
+    parameters = load_default_parameters()
+    assert parameters.iterations == 30000
+    assert parameters.sh_degree == 3
+    assert parameters.ssim_lambda == pytest.approx(0.5)
+    assert parameters.strategy == gsplat_pb2.STRATEGY_MCMC
+    assert parameters.absgrad is True
+
+
+def test_omitted_fields_keep_the_default_rather_than_proto3_zero(tmp_path):
+    """The layering load_parameters exists for: a partial file is not a reset."""
+    path = tmp_path / "partial.textproto"
+    path.write_text("iterations: 7000\n")
+
+    parameters = load_parameters(path)
+
+    assert parameters.iterations == 7000
+    assert parameters.sh_degree == 3
+    assert parameters.ssim_lambda == pytest.approx(0.5)
+    assert parameters.strategy == gsplat_pb2.STRATEGY_MCMC
+
+
+def test_named_fields_override_the_default(tmp_path):
+    path = tmp_path / "override.textproto"
+    path.write_text("strategy: STRATEGY_DEFAULT\nsh_degree: 1\nabsgrad: false\n")
+
+    parameters = load_parameters(path)
+
+    assert parameters.strategy == gsplat_pb2.STRATEGY_DEFAULT
+    assert parameters.sh_degree == 1
+    assert parameters.absgrad is False
+    assert parameters.iterations == 30000
+
+
+def test_unknown_field_is_rejected(tmp_path):
+    path = tmp_path / "typo.textproto"
+    path.write_text("iteration_count: 10\n")
+
+    with pytest.raises(Exception):
+        load_parameters(path)
+
+
+def test_dict_round_trip_keeps_snake_case_names():
+    parameters = parameters_from_dict({"iterations": 500, "sh_degree": 2})
+
+    assert parameters.iterations == 500
+    assert parameters_to_dict(parameters) == {"iterations": 500, "sh_degree": 2}
+
+
+def test_dict_round_trip_preserves_the_enum():
+    parameters = parameters_from_dict({"strategy": "STRATEGY_MCMC", "cap_max": 1000})
+
+    assert parameters.strategy == gsplat_pb2.STRATEGY_MCMC
+    assert parameters_to_dict(parameters)["strategy"] == "STRATEGY_MCMC"
+
+
+def test_defaults_survive_a_text_round_trip(tmp_path):
+    original = load_default_parameters()
+    path = tmp_path / "round_trip.textproto"
+    path.write_text(parameters_to_text(original))
+
+    assert load_parameters(path) == original
+
+
+def test_dict_of_defaults_reparses_to_the_same_message():
+    original = load_default_parameters()
+
+    assert parameters_from_dict(parameters_to_dict(original)) == original

--- a/gsplat_server/proto/build.sh
+++ b/gsplat_server/proto/build.sh
@@ -3,13 +3,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROTOC_PLUGIN="$(command -v grpc_python_plugin)"
+PROTOC_FLAGS=(
+  -I "${SCRIPT_DIR}"
+  --python_out="${SCRIPT_DIR}"
+  --grpc_python_out="${SCRIPT_DIR}"
+)
 
-protoc -I "${SCRIPT_DIR}" \
-  --python_out="${SCRIPT_DIR}" \
-  --grpc_python_out="${SCRIPT_DIR}" \
-  --plugin="protoc-gen-grpc_python=${PROTOC_PLUGIN}" \
-  "${SCRIPT_DIR}/gsplat.proto"
+# The images ship no protoc, so fall back to the copy grpcio-tools bundles,
+# which is version-matched to the protobuf runtime it installed alongside.
+if command -v protoc >/dev/null && command -v grpc_python_plugin >/dev/null; then
+  protoc "${PROTOC_FLAGS[@]}" \
+    --plugin="protoc-gen-grpc_python=$(command -v grpc_python_plugin)" \
+    "${SCRIPT_DIR}/gsplat.proto"
+else
+  python3 -m grpc_tools.protoc "${PROTOC_FLAGS[@]}" "${SCRIPT_DIR}/gsplat.proto"
+fi
 
 sed -i 's/^import gsplat_pb2 as gsplat__pb2$/from . import gsplat_pb2 as gsplat__pb2/' \
   "${SCRIPT_DIR}/gsplat_pb2_grpc.py"

--- a/gsplat_server/server_test.py
+++ b/gsplat_server/server_test.py
@@ -1,0 +1,371 @@
+"""Tests for the gsplat gRPC service's job store, uploads and command building."""
+
+import json
+import queue
+import zipfile
+
+import grpc
+import pytest
+
+from gsplat_server import server
+from gsplat_server.parameters import load_default_parameters, parameters_to_dict
+from gsplat_server.proto import gsplat_pb2
+
+
+class Aborted(Exception):
+    def __init__(self, code, details):
+        super().__init__(details)
+        self.code, self.details = code, details
+
+
+class FakeContext:
+    """Stands in for a gRPC context, whose abort() raises rather than returns."""
+
+    def abort(self, code, details):
+        raise Aborted(code, details)
+
+
+@pytest.fixture
+def store(tmp_path):
+    root = tmp_path / "jobs"
+    root.mkdir()
+    return server.JobStore(root)
+
+
+@pytest.fixture
+def parameters():
+    return parameters_to_dict(load_default_parameters())
+
+
+def write_archive(path, names):
+    with zipfile.ZipFile(path, "w") as archive:
+        for name in names:
+            archive.writestr(name, "content")
+    return path
+
+
+# --- JobStore -------------------------------------------------------------
+
+
+def test_create_writes_a_queued_job_to_disk(store, parameters):
+    job = store.create(parameters)
+
+    assert job["state"] == server.QUEUED
+    assert job["started_at"] is None
+    on_disk = json.loads((store.directory(job["id"]) / "job.json").read_text())
+    assert on_disk == job
+
+
+def test_update_persists_the_change(store, parameters):
+    job = store.create(parameters)
+
+    store.update(job, state=server.SUCCEEDED, error=None)
+
+    assert store.get(job["id"])["state"] == server.SUCCEEDED
+    on_disk = json.loads((store.directory(job["id"]) / "job.json").read_text())
+    assert on_disk["state"] == server.SUCCEEDED
+
+
+def test_get_returns_none_for_an_unknown_job(store):
+    assert store.get("nope") is None
+
+
+def test_list_is_ordered_by_creation_time(store, parameters):
+    first = store.create(parameters)
+    second = store.create(parameters)
+    store.update(first, created_at=2.0)
+    store.update(second, created_at=1.0)
+
+    assert [job["id"] for job in store.list()] == [second["id"], first["id"]]
+
+
+@pytest.mark.parametrize("state", [server.QUEUED, server.RUNNING])
+def test_a_restart_fails_the_jobs_that_were_in_flight(store, parameters, state):
+    job = store.create(parameters)
+    store.update(job, state=state)
+
+    reloaded = server.JobStore(store.root).get(job["id"])
+
+    assert reloaded["state"] == server.FAILED
+    assert reloaded["error"] == "interrupted by a server restart"
+
+
+@pytest.mark.parametrize("state", [server.SUCCEEDED, server.FAILED])
+def test_a_restart_leaves_finished_jobs_alone(store, parameters, state):
+    job = store.create(parameters)
+    store.update(job, state=state, error=None)
+
+    assert server.JobStore(store.root).get(job["id"])["state"] == state
+
+
+def test_remove_deletes_the_directory_and_the_index_entry(store, parameters):
+    job = store.create(parameters)
+    directory = store.directory(job["id"])
+
+    store.remove(job)
+
+    assert not directory.exists()
+    assert store.get(job["id"]) is None
+
+
+# --- extract_model --------------------------------------------------------
+
+
+def test_a_flat_archive_becomes_the_model_directory(tmp_path):
+    archive = write_archive(tmp_path / "u.zip", ["images/a.png", "sparse/0/cameras.bin"])
+    destination = tmp_path / "model"
+
+    server.extract_model(archive, destination)
+
+    assert (destination / "images" / "a.png").is_file()
+    assert (destination / "sparse" / "0" / "cameras.bin").is_file()
+    assert not (tmp_path / "staging").exists()
+
+
+def test_a_single_wrapper_directory_is_stripped(tmp_path):
+    archive = write_archive(
+        tmp_path / "u.zip", ["capture/images/a.png", "capture/sparse/0/cameras.bin"]
+    )
+    destination = tmp_path / "model"
+
+    server.extract_model(archive, destination)
+
+    assert (destination / "images" / "a.png").is_file()
+    assert not (destination / "capture").exists()
+
+
+@pytest.mark.parametrize("name", ["../escape.txt", "nested/../../escape.txt", "/etc/passwd"])
+def test_a_path_outside_the_destination_is_refused(tmp_path, name):
+    archive = write_archive(tmp_path / "u.zip", ["images/a.png", "sparse/x.bin", name])
+
+    with pytest.raises(ValueError, match="unsafe path in archive"):
+        server.extract_model(archive, tmp_path / "model")
+
+    assert not (tmp_path / "model").exists()
+
+
+def test_an_archive_without_images_and_sparse_is_refused(tmp_path):
+    archive = write_archive(tmp_path / "u.zip", ["images/a.png"])
+
+    with pytest.raises(ValueError, match="no directory with both"):
+        server.extract_model(archive, tmp_path / "model")
+
+    assert not (tmp_path / "staging").exists()
+
+
+def test_a_corrupt_archive_raises_badzipfile(tmp_path):
+    archive = tmp_path / "u.zip"
+    archive.write_bytes(b"not a zip")
+
+    with pytest.raises(zipfile.BadZipFile):
+        server.extract_model(archive, tmp_path / "model")
+
+
+# --- results and commands -------------------------------------------------
+
+
+def test_result_ply_is_none_before_training_writes_one(tmp_path):
+    assert server.result_ply(tmp_path) is None
+
+
+def test_result_ply_finds_the_saved_point_cloud(tmp_path):
+    ply_dir = tmp_path / "model" / "gsplat_output" / "ply"
+    ply_dir.mkdir(parents=True)
+    (ply_dir / "point_cloud_30000.ply").write_bytes(b"ply")
+
+    assert server.result_ply(tmp_path) == ply_dir / "point_cloud_30000.ply"
+
+
+def test_training_command_points_at_the_job_directory(tmp_path):
+    command = server.training_command(tmp_path)
+
+    assert str(server.TRAIN_ENTRYPOINT) in command
+    assert str(tmp_path / "parameters.textproto") in command
+    assert str(tmp_path / "model") in command
+    assert "--disable_viewer" in command and "--disable_video" in command
+
+
+def test_segmentation_command_reads_images_and_writes_masks(tmp_path):
+    command = server.segmentation_command(tmp_path)
+
+    assert command[-2:] == [str(tmp_path / "images"), str(tmp_path / "masks")]
+
+
+def test_training_is_the_only_step_when_segmentation_is_off(tmp_path, parameters):
+    parameters["run_segmentation"] = False
+
+    steps = server.job_steps({"parameters": parameters}, tmp_path)
+
+    assert [name for name, _ in steps] == ["gsplat training"]
+
+
+def test_segmentation_runs_before_training_when_asked_for(tmp_path, parameters):
+    parameters["run_segmentation"] = True
+
+    steps = server.job_steps({"parameters": parameters}, tmp_path)
+
+    assert [name for name, _ in steps] == ["segmentation", "gsplat training"]
+
+
+def test_an_uploaded_masks_directory_is_never_overwritten(tmp_path, parameters):
+    parameters["run_segmentation"] = True
+    (tmp_path / "model" / "masks").mkdir(parents=True)
+
+    steps = server.job_steps({"parameters": parameters}, tmp_path)
+
+    assert [name for name, _ in steps] == ["gsplat training"]
+
+
+def test_as_proto_maps_unset_timestamps_to_zero(store, parameters):
+    job = store.create(parameters)
+    store.update(job, created_at=1.5)
+
+    proto = server.as_proto(job)
+
+    assert (proto.id, proto.state) == (job["id"], server.QUEUED)
+    assert proto.created_at == pytest.approx(1.5)
+    assert proto.started_at == 0 and proto.finished_at == 0
+    assert proto.error == ""
+
+
+# --- write_upload ---------------------------------------------------------
+
+
+def submit(parameters=None, chunks=()):
+    requests = []
+    if parameters is not None:
+        requests.append(gsplat_pb2.SubmitJobRequest(parameters=parameters))
+    requests += [gsplat_pb2.SubmitJobRequest(archive_chunk=chunk) for chunk in chunks]
+    return requests
+
+
+def test_write_upload_saves_the_archive_and_the_parameters(store):
+    parameters = load_default_parameters()
+
+    job = server.write_upload(
+        submit(parameters, [b"abc", b"def"]), store, FakeContext()
+    )
+
+    directory = store.directory(job["id"])
+    assert (directory / "upload.zip").read_bytes() == b"abcdef"
+    assert "iterations: 30000" in (directory / "parameters.textproto").read_text()
+
+
+def test_a_chunk_before_the_parameters_is_refused(store):
+    with pytest.raises(Aborted) as error:
+        server.write_upload(submit(chunks=[b"abc"]), store, FakeContext())
+
+    assert error.value.code == grpc.StatusCode.INVALID_ARGUMENT
+    assert "parameters must be first" in error.value.details
+
+
+def test_parameters_sent_twice_are_refused(store):
+    parameters = load_default_parameters()
+    requests = submit(parameters, [b"abc"]) + submit(parameters)
+
+    with pytest.raises(Aborted, match="parameters sent more than once"):
+        server.write_upload(requests, store, FakeContext())
+
+
+def test_an_upload_without_parameters_is_refused(store):
+    with pytest.raises(Aborted, match="missing job parameters"):
+        server.write_upload(submit(), store, FakeContext())
+
+
+# --- service methods ------------------------------------------------------
+
+
+@pytest.fixture
+def service(store):
+    return server.GsplatService(store, queue.Queue())
+
+
+def test_get_job_reports_an_unknown_id_as_not_found(service):
+    with pytest.raises(Aborted) as error:
+        service.GetJob(gsplat_pb2.GetJobRequest(id="missing"), FakeContext())
+
+    assert error.value.code == grpc.StatusCode.NOT_FOUND
+
+
+def test_list_jobs_returns_every_stored_job(service, store, parameters):
+    store.create(parameters)
+    store.create(parameters)
+
+    response = service.ListJobs(gsplat_pb2.ListJobsRequest(), FakeContext())
+
+    assert len(response.jobs) == 2
+
+
+def test_a_queued_job_cannot_be_deleted(service, store, parameters):
+    job = store.create(parameters)
+
+    with pytest.raises(Aborted) as error:
+        service.DeleteJob(gsplat_pb2.DeleteJobRequest(id=job["id"]), FakeContext())
+
+    assert error.value.code == grpc.StatusCode.FAILED_PRECONDITION
+    assert store.get(job["id"]) is not None
+
+
+def test_a_finished_job_is_deleted(service, store, parameters):
+    job = store.create(parameters)
+    store.update(job, state=server.SUCCEEDED)
+
+    response = service.DeleteJob(
+        gsplat_pb2.DeleteJobRequest(id=job["id"]), FakeContext()
+    )
+
+    assert response.id == job["id"]
+    assert store.get(job["id"]) is None
+
+
+def test_the_result_of_an_unfinished_job_cannot_be_downloaded(service, store, parameters):
+    job = store.create(parameters)
+
+    with pytest.raises(Aborted, match="is queued"):
+        list(service.DownloadResult(
+            gsplat_pb2.DownloadResultRequest(id=job["id"]), FakeContext()
+        ))
+
+
+def test_a_succeeded_job_without_a_point_cloud_reports_no_result(service, store, parameters):
+    job = store.create(parameters)
+    store.update(job, state=server.SUCCEEDED)
+
+    with pytest.raises(Aborted, match="no result yet"):
+        list(service.DownloadResult(
+            gsplat_pb2.DownloadResultRequest(id=job["id"]), FakeContext()
+        ))
+
+
+def test_the_point_cloud_is_streamed_back(service, store, parameters):
+    job = store.create(parameters)
+    store.update(job, state=server.SUCCEEDED)
+    ply_dir = store.directory(job["id"]) / "model" / "gsplat_output" / "ply"
+    ply_dir.mkdir(parents=True)
+    (ply_dir / "point_cloud_30000.ply").write_bytes(b"point cloud")
+
+    chunks = list(service.DownloadResult(
+        gsplat_pb2.DownloadResultRequest(id=job["id"]), FakeContext()
+    ))
+
+    assert b"".join(chunk.data for chunk in chunks) == b"point cloud"
+
+
+def test_the_log_is_streamed_from_the_requested_offset(service, store, parameters):
+    job = store.create(parameters)
+    (store.directory(job["id"]) / "train.log").write_bytes(b"0123456789")
+
+    chunks = list(service.StreamLog(
+        gsplat_pb2.StreamLogRequest(id=job["id"], offset=4), FakeContext()
+    ))
+
+    assert b"".join(chunk.data for chunk in chunks) == b"456789"
+    assert chunks[-1].offset == 10
+
+
+def test_streaming_the_log_of_a_job_that_has_not_started_yields_nothing(service, store, parameters):
+    job = store.create(parameters)
+
+    assert list(service.StreamLog(
+        gsplat_pb2.StreamLogRequest(id=job["id"]), FakeContext()
+    )) == []

--- a/mapping/benchmark/summarize_gsplat_sweep_test.py
+++ b/mapping/benchmark/summarize_gsplat_sweep_test.py
@@ -1,0 +1,404 @@
+"""Tests for the gsplat parameter-sweep report generator."""
+
+import json
+import os
+
+import numpy as np
+import pytest
+import yaml
+from PIL import Image
+
+from mapping.benchmark import summarize_gsplat_sweep as summarize
+
+PLY_PROPERTIES = ("x", "y", "z", "opacity", "scale_0", "scale_1", "scale_2")
+
+
+def write_ply(path, rows):
+    header = "ply\nformat binary_little_endian 1.0\n"
+    header += f"element vertex {len(rows)}\n"
+    header += "".join(f"property float {name}\n" for name in PLY_PROPERTIES)
+    header += "end_header\n"
+    with path.open("wb") as handle:
+        handle.write(header.encode("ascii"))
+        np.asarray(rows, "<f4").tofile(handle)
+    return path
+
+
+def gaussian(x=0.0, opacity=0.0):
+    return [x, 0.0, 0.0, opacity, 0.0, 0.0, 0.0]
+
+
+METRIC_KEYS = ("gaussians", "psnr", "ssim", "lpips", "train_seconds", "peak_memory_gib")
+
+
+def run(name, metrics=None, **overrides):
+    """A collected run, shaped the way collect_run returns one."""
+    return {
+        "name": name,
+        "parameters": {},
+        "metrics": {**dict.fromkeys(METRIC_KEYS), **(metrics or {})},
+        "geometry": {},
+        "ply_path": None,
+        "renders": [],
+        "video_path": None,
+        "log_path": None,
+        "exit_status": None,
+        "wall_seconds": None,
+        "complete": True,
+        **overrides,
+    }
+
+
+# --- small helpers --------------------------------------------------------
+
+
+def test_flatten_parameters_joins_nested_keys_with_dots():
+    flattened = summarize.flatten_parameters(
+        {"max_steps": 30000, "strategy": {"cap_max": 900000, "nested": {"deep": 1}}}
+    )
+
+    assert flattened == {
+        "max_steps": 30000,
+        "strategy.cap_max": 900000,
+        "strategy.nested.deep": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [("val_step6999.json", 6999), ("point_cloud_30000.ply", 30000), ("cfg.yml", -1)],
+)
+def test_step_number_reads_the_first_run_of_digits(name, expected):
+    assert summarize.step_number(name) == expected
+
+
+def test_latest_step_file_orders_by_step_not_by_name(tmp_path):
+    """29999 sorts before 6999 lexicographically, so plain sorting picks the wrong file."""
+    for step in (6999, 29999):
+        (tmp_path / f"val_step{step}.json").write_text("{}")
+
+    latest = summarize.latest_step_file(tmp_path, "val_step*.json")
+
+    assert latest.name == "val_step29999.json"
+
+
+def test_latest_step_file_is_none_when_nothing_matches(tmp_path):
+    assert summarize.latest_step_file(tmp_path, "val_step*.json") is None
+
+
+def test_read_json_of_a_missing_file_is_empty():
+    assert summarize.read_json(None) == {}
+
+
+@pytest.mark.parametrize(
+    "seconds, expected", [(None, summarize.MISSING), (0, "0 min"), (59, "0 min"),
+                          (90, "1 min"), (3660, "1 h 01 min"), (7200, "2 h 00 min")]
+)
+def test_format_duration(seconds, expected):
+    assert summarize.format_duration(seconds) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected", [([1, 2, 3], "1, 2, 3"), (0.5, "0.5"), (True, "True")]
+)
+def test_format_value(value, expected):
+    assert summarize.format_value(value) == expected
+
+
+def test_relative_uses_forward_slashes(tmp_path):
+    target = tmp_path / "runs" / "a.ply"
+
+    assert summarize.relative(target, tmp_path) == "runs/a.ply"
+
+
+def test_read_status_splits_each_line_on_the_first_space(tmp_path):
+    path = tmp_path / "sweep_status.txt"
+    path.write_text("exit_status 0\nwall_seconds 1234.5\n")
+
+    assert summarize.read_status(path) == {"exit_status": "0", "wall_seconds": "1234.5"}
+
+
+def test_read_status_of_a_missing_file_is_empty(tmp_path):
+    assert summarize.read_status(tmp_path / "absent.txt") == {}
+
+
+# --- PLY reading and geometry --------------------------------------------
+
+
+def test_read_ply_returns_the_properties_and_the_values(tmp_path):
+    path = write_ply(tmp_path / "a.ply", [gaussian(x=1.0), gaussian(x=2.0)])
+
+    names, values = summarize.read_ply(path)
+
+    assert names == list(PLY_PROPERTIES)
+    assert values.shape == (2, len(PLY_PROPERTIES))
+    assert values[1, 0] == pytest.approx(2.0)
+
+
+def test_read_ply_rejects_a_truncated_header(tmp_path):
+    path = tmp_path / "truncated.ply"
+    path.write_bytes(b"ply\nformat binary_little_endian 1.0\nelement vertex 1\n")
+
+    with pytest.raises(ValueError, match="truncated PLY header"):
+        summarize.read_ply(path)
+
+
+def test_ply_geometry_converts_opacity_and_scale(tmp_path):
+    # opacity 0 is sigmoid 0.5; one Gaussian at -5 is faint. scale 0 is radius 1.
+    path = write_ply(tmp_path / "a.ply", [
+        gaussian(x=0.0, opacity=0.0),
+        gaussian(x=1.0, opacity=0.0),
+        gaussian(x=2.0, opacity=0.0),
+        gaussian(x=3.0, opacity=-5.0),
+    ])
+
+    geometry = summarize.ply_geometry(path)
+
+    assert geometry["gaussians"] == 4
+    assert geometry["median_opacity"] == pytest.approx(0.5, abs=1e-3)
+    assert geometry["faint_fraction"] == pytest.approx(0.25)
+    assert geometry["median_radius"] == pytest.approx(1.0)
+    assert geometry["neighbour_spacing"] == pytest.approx(1.0)
+    assert geometry["radius_over_spacing"] == pytest.approx(1.0)
+
+
+def test_ply_geometry_leaves_the_ratio_unset_when_every_point_coincides(tmp_path):
+    path = write_ply(tmp_path / "a.ply", [gaussian(), gaussian(), gaussian()])
+
+    geometry = summarize.ply_geometry(path)
+
+    assert geometry["neighbour_spacing"] == pytest.approx(0.0)
+    assert geometry["radius_over_spacing"] is None
+
+
+def test_median_neighbour_distance_needs_two_points():
+    assert summarize.median_neighbour_distance(np.zeros((1, 3), "<f4")) is None
+    assert summarize.median_neighbour_distance(np.zeros((0, 3), "<f4")) is None
+
+
+def test_median_neighbour_distance_recovers_a_regular_grid_spacing():
+    grid = np.stack(np.meshgrid(*[np.arange(5.0)] * 3), -1).reshape(-1, 3)
+
+    spacing = summarize.median_neighbour_distance(grid.astype("<f4"))
+
+    assert spacing == pytest.approx(1.0, rel=0.15)
+
+
+# --- table and cell formatting -------------------------------------------
+
+
+def test_table_writes_a_markdown_header_and_separator():
+    rendered = summarize.table(["A", "B"], [["1", "2"], ["3", "4"]])
+
+    assert rendered.splitlines() == [
+        "| A | B |", "| --- | --- |", "| 1 | 2 |", "| 3 | 4 |"
+    ]
+
+
+def test_best_values_takes_the_max_for_psnr_and_the_min_for_lpips():
+    runs = [run("a", metrics={"psnr": 20.0, "lpips": 0.4}),
+            run("b", metrics={"psnr": 25.0, "lpips": 0.2})]
+
+    best = summarize.best_values(runs, summarize.METRIC_COLUMNS, "metrics")
+
+    assert best["psnr"] == 25.0
+    assert best["lpips"] == 0.2
+    assert best["gaussians"] is None
+
+
+def test_value_cells_bolds_the_winner_and_marks_the_gaps():
+    runs = [run("a", metrics={"psnr": 20.0, "lpips": 0.4}),
+            run("b", metrics={"psnr": 25.0, "lpips": 0.2})]
+    best = summarize.best_values(runs, summarize.METRIC_COLUMNS, "metrics")
+
+    cells = summarize.value_cells(runs[1], summarize.METRIC_COLUMNS, best, "metrics")
+
+    assert cells == [summarize.MISSING, "**25.00**", summarize.MISSING, "**0.2000**"]
+
+
+# --- report sections ------------------------------------------------------
+
+
+def test_parameters_section_lists_only_the_values_that_differ():
+    runs = [run("a", parameters={"sh_degree": 3, "max_steps": 30000}),
+            run("b", parameters={"sh_degree": 1, "max_steps": 30000})]
+
+    section = summarize.parameters_section(runs)
+
+    assert "`sh_degree`" in section
+    assert "`max_steps`" not in section
+
+
+def test_parameters_section_ignores_the_run_specific_paths():
+    runs = [run("a", parameters={"result_dir": "/runs/a", "data_dir": "/data/a"}),
+            run("b", parameters={"result_dir": "/runs/b", "data_dir": "/data/b"})]
+
+    assert "Every run used identical settings." in summarize.parameters_section(runs)
+
+
+def test_parameters_section_says_so_when_nothing_differs():
+    runs = [run("a", parameters={"sh_degree": 3}), run("b", parameters={"sh_degree": 3})]
+
+    assert "Every run used identical settings." in summarize.parameters_section(runs)
+
+
+def test_pending_section_is_empty_when_every_run_finished_cleanly():
+    runs = [run("a", exit_status="0"), run("b", exit_status=None)]
+
+    assert summarize.pending_section(runs) == ""
+
+
+def test_pending_section_reports_unfinished_and_failed_runs():
+    runs = [run("a", complete=False), run("b", exit_status="1")]
+
+    section = summarize.pending_section(runs)
+
+    assert "Still training or not yet evaluated:** `a`" in section
+    assert "`b` (exit 1)" in section
+
+
+def test_renders_section_says_so_when_no_renders_exist(tmp_path):
+    assert "No validation renders written yet." in summarize.renders_section(
+        [run("a")], [], {}, tmp_path
+    )
+
+
+def test_metrics_section_links_the_artifacts_relative_to_the_report(tmp_path):
+    ply = write_ply(tmp_path / "point_cloud_30000.ply", [gaussian()])
+    runs = [run("a", metrics={"psnr": 25.0, "train_seconds": 3660}, ply_path=ply)]
+
+    section = summarize.metrics_section(runs, tmp_path)
+
+    assert "[ply 0 MB](point_cloud_30000.ply)" in section
+    assert "1 h 01 min" in section
+
+
+def test_build_report_assembles_every_section(tmp_path):
+    runs = [run("a", metrics={"psnr": 25.0}, parameters={"sh_degree": 3})]
+
+    report = summarize.build_report(runs, tmp_path / "report.md", [], {}, "the command")
+
+    assert report.startswith("# gsplat parameter sweep")
+    assert "1 configurations" in report
+    assert "## Metrics and point-cloud geometry" in report
+    assert "## Settings under test" in report
+    assert "## Renders" in report
+    assert "Regenerate with `the command`." in report
+    assert report.endswith("\n")
+
+
+# --- configuration loading and collection --------------------------------
+
+
+def test_the_loader_reads_a_config_with_a_gsplat_python_tag():
+    document = (
+        "max_steps: 30000\n"
+        "strategy: !!python/object:gsplat.strategy.mcmc.MCMCStrategy\n"
+        "  cap_max: 900000\n"
+    )
+
+    configuration = yaml.load(document, Loader=summarize.TagTolerantLoader)
+
+    assert configuration["max_steps"] == 30000
+    assert configuration["strategy"] == {"cap_max": 900000}
+
+
+def make_run_directory(root, name, validation=True):
+    step = 30000
+    run_dir = root / name
+    (run_dir / "stats").mkdir(parents=True)
+    (run_dir / "ply").mkdir()
+    (run_dir / "cfg.yml").write_text(
+        "max_steps: 30000\nstrategy: !!python/object:gsplat.strategy.MCMC\n  cap_max: 900000\n"
+    )
+    if validation:
+        (run_dir / "stats" / f"val_step{step}.json").write_text(
+            json.dumps({"num_GS": 12345, "psnr": 25.5, "ssim": 0.9, "lpips": 0.15})
+        )
+    (run_dir / "stats" / f"train_step{step}.json").write_text(
+        json.dumps({"ellipse_time": 3600.0, "mem": 12.5})
+    )
+    write_ply(run_dir / "ply" / f"point_cloud_{step}.ply", [gaussian(), gaussian(x=1.0)])
+    (run_dir / "sweep_status.txt").write_text("exit_status 0\nwall_seconds 3700.0\n")
+    return run_dir
+
+
+def test_collect_run_gathers_the_metrics_and_the_artifacts(tmp_path):
+    run_dir = make_run_directory(tmp_path, "mcmc_900k")
+
+    collected = summarize.collect_run(run_dir)
+
+    assert collected["name"] == "mcmc_900k"
+    assert collected["complete"] is True
+    assert collected["exit_status"] == "0"
+    assert collected["wall_seconds"] == pytest.approx(3700.0)
+    assert collected["metrics"]["gaussians"] == 12345
+    assert collected["metrics"]["psnr"] == pytest.approx(25.5)
+    assert collected["metrics"]["peak_memory_gib"] == pytest.approx(12.5)
+    assert collected["parameters"]["strategy.cap_max"] == 900000
+    assert collected["geometry"]["gaussians"] == 2
+    assert collected["ply_path"].name == "point_cloud_30000.ply"
+    assert collected["log_path"] is None
+
+
+def test_collect_run_of_a_run_still_training_falls_back_to_the_point_cloud(tmp_path):
+    run_dir = make_run_directory(tmp_path, "pending", validation=False)
+
+    collected = summarize.collect_run(run_dir)
+
+    assert collected["complete"] is False
+    assert collected["metrics"]["psnr"] is None
+    # No val_step*.json yet, so the count comes from the PLY the trainer saved.
+    assert collected["metrics"]["gaussians"] == 2
+
+
+# --- thumbnails -----------------------------------------------------------
+
+
+def write_render(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (40, 10), "red").save(path)
+    return path
+
+
+def test_write_thumbnails_splits_the_render_into_truth_and_prediction(tmp_path):
+    render = write_render(tmp_path / "a" / "renders" / "val_step30000_0000.png")
+    runs = [run("a", renders=[render])]
+
+    truth_paths, predicted_paths = summarize.write_thumbnails(
+        runs, tmp_path / "assets", view_count=1
+    )
+
+    assert [path.name for path in truth_paths] == ["view00_truth.jpg"]
+    assert predicted_paths["a"][0].name == "view00_a.jpg"
+    assert Image.open(truth_paths[0]).size == (summarize.THUMBNAIL_WIDTH, 210)
+
+
+def test_write_thumbnails_does_nothing_without_renders(tmp_path):
+    assert summarize.write_thumbnails([run("a")], tmp_path / "assets", 6) == ([], {})
+    assert not (tmp_path / "assets").exists()
+
+
+def test_thumbnails_are_left_alone_when_they_are_newer_than_the_render(tmp_path):
+    render = write_render(tmp_path / "a" / "renders" / "val_step30000_0000.png")
+    runs = [run("a", renders=[render])]
+    assets = tmp_path / "assets"
+    summarize.write_thumbnails(runs, assets, view_count=1)
+    thumbnail = assets / "view00_a.jpg"
+    stamp = thumbnail.stat().st_mtime_ns
+
+    summarize.write_thumbnails(runs, assets, view_count=1)
+
+    assert thumbnail.stat().st_mtime_ns == stamp
+
+
+def test_is_current_compares_modification_times(tmp_path):
+    source = write_render(tmp_path / "source.png")
+    thumbnail = tmp_path / "thumbnail.jpg"
+
+    assert not summarize.is_current(thumbnail, source)
+
+    thumbnail.write_bytes(b"jpeg")
+    os.utime(thumbnail, ns=(source.stat().st_mtime_ns + 10**9,) * 2)
+
+    assert summarize.is_current(thumbnail, source)

--- a/mapping/mapping_pipeline_test.py
+++ b/mapping/mapping_pipeline_test.py
@@ -1,0 +1,191 @@
+"""Tests for the mapping pipeline's gravity levelling."""
+
+import sys
+import types
+
+import numpy as np
+import pycolmap
+import pytest
+
+# features.triton_models refuses to import without the EasyTensorRT submodule,
+# and reaching it needs a Triton endpoint. The levelling touches neither.
+_triton_models = types.ModuleType("mapping.features.triton_models")
+for _name in ("FeatureMatcher", "GlobalFeatureExtractor", "LocalFeatureExtractor",
+              "LocalFeatures"):
+    setattr(_triton_models, _name, type(_name, (), {}))
+sys.modules.setdefault("mapping.features.triton_models", _triton_models)
+
+from mapping.mapping_pipeline import (  # noqa: E402
+    _rotation_to_world_down,
+    align_up_axis,
+)
+from mapping.panorama_database import RIG_DOWN  # noqa: E402
+
+WORLD_DOWN = np.array([0.0, 0.0, -1.0])
+
+
+class Frame:
+    def __init__(self, rotation=None, has_pose=True):
+        self.rig_from_world = pycolmap.Rigid3d(
+            rotation if rotation is not None else pycolmap.Rotation3d(), np.zeros(3)
+        )
+        self.has_pose = has_pose
+
+
+class Reconstruction:
+    """Only what align_up_axis reads: the frames, and the transform it applies."""
+
+    def __init__(self, *frames):
+        self.frames = dict(enumerate(frames))
+        self.applied = []
+
+    def transform(self, sim3d):
+        self.applied.append(sim3d)
+
+
+def rotation_about_x(degrees):
+    half = np.radians(degrees) / 2.0
+    return pycolmap.Rotation3d(np.array([np.sin(half), 0.0, 0.0, np.cos(half)]))
+
+
+def rig_down_in_world(frame):
+    return frame.rig_from_world.rotation.inverse() * RIG_DOWN
+
+
+def unit(vector):
+    return vector / np.linalg.norm(vector)
+
+
+# --- align_up_axis --------------------------------------------------------
+
+
+def test_a_level_map_puts_the_rig_down_axis_on_minus_z():
+    reconstruction = Reconstruction(Frame())
+
+    align_up_axis(reconstruction)
+
+    (applied,) = reconstruction.applied
+    assert applied.rotation * unit(RIG_DOWN) == pytest.approx(WORLD_DOWN, abs=1e-6)
+
+
+@pytest.mark.parametrize("tilt", [10.0, 30.0, 90.0, -45.0, 179.0])
+def test_a_tilted_map_is_levelled(tilt):
+    frame = Frame(rotation_about_x(tilt))
+    reconstruction = Reconstruction(frame)
+
+    align_up_axis(reconstruction)
+
+    (applied,) = reconstruction.applied
+    levelled = applied.rotation * rig_down_in_world(frame)
+    assert levelled == pytest.approx(WORLD_DOWN, abs=1e-6)
+
+
+def test_gravity_is_averaged_over_the_frames():
+    frames = [Frame(rotation_about_x(20.0)), Frame(rotation_about_x(-40.0))]
+    reconstruction = Reconstruction(*frames)
+
+    align_up_axis(reconstruction)
+
+    (applied,) = reconstruction.applied
+    average = unit(sum(rig_down_in_world(frame) for frame in frames))
+    assert applied.rotation * average == pytest.approx(WORLD_DOWN, abs=1e-6)
+    # The average is a direction neither frame reports on its own.
+    for frame in frames:
+        assert applied.rotation * rig_down_in_world(frame) != pytest.approx(
+            WORLD_DOWN, abs=1e-3
+        )
+
+
+def test_frames_without_a_pose_are_ignored():
+    posed = Frame(rotation_about_x(25.0))
+    with_unposed = Reconstruction(posed, Frame(rotation_about_x(140.0), has_pose=False))
+    posed_only = Reconstruction(Frame(rotation_about_x(25.0)))
+
+    align_up_axis(with_unposed)
+    align_up_axis(posed_only)
+
+    assert with_unposed.applied[0].rotation.matrix() == pytest.approx(
+        posed_only.applied[0].rotation.matrix(), abs=1e-6
+    )
+
+
+def test_a_map_with_no_registered_frames_is_left_alone():
+    reconstruction = Reconstruction(Frame(has_pose=False), Frame(has_pose=False))
+
+    align_up_axis(reconstruction)
+
+    assert reconstruction.applied == []
+
+
+def test_an_empty_reconstruction_is_left_alone():
+    reconstruction = Reconstruction()
+
+    align_up_axis(reconstruction)
+
+    assert reconstruction.applied == []
+
+
+def test_opposing_frames_that_cancel_leave_the_map_as_solved():
+    """Averaging to zero has no axis to level, so the map is left as solved."""
+    reconstruction = Reconstruction(Frame(), Frame(rotation_about_x(180.0)))
+
+    align_up_axis(reconstruction)
+
+    assert reconstruction.applied == []
+
+
+def test_levelling_keeps_the_scale_and_position_the_mapper_solved():
+    reconstruction = Reconstruction(Frame(rotation_about_x(30.0)))
+
+    align_up_axis(reconstruction)
+
+    (applied,) = reconstruction.applied
+    assert applied.scale == pytest.approx(1.0)
+    assert applied.translation == pytest.approx(np.zeros(3))
+
+
+# --- _rotation_to_world_down ---------------------------------------------
+
+
+def test_an_already_level_axis_needs_no_rotation():
+    rotation = _rotation_to_world_down(WORLD_DOWN)
+
+    assert rotation.matrix() == pytest.approx(np.eye(3), abs=1e-9)
+
+
+def test_an_upside_down_axis_turns_a_half_turn():
+    """The antipodal case has no shortest arc, so any horizontal axis serves."""
+    rotation = _rotation_to_world_down(np.array([0.0, 0.0, 1.0]))
+
+    assert rotation * np.array([0.0, 0.0, 1.0]) == pytest.approx(WORLD_DOWN, abs=1e-9)
+
+
+@pytest.mark.parametrize(
+    "down",
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, -1.0],
+        [1.0, 1.0, -1.0],
+        [-0.3, 0.5, 0.81],
+    ],
+)
+def test_any_axis_lands_on_minus_z(down):
+    down = unit(np.array(down))
+
+    rotation = _rotation_to_world_down(down)
+
+    assert rotation * down == pytest.approx(WORLD_DOWN, abs=1e-6)
+    matrix = rotation.matrix()
+    assert matrix @ matrix.T == pytest.approx(np.eye(3), abs=1e-6)
+    assert np.linalg.det(matrix) == pytest.approx(1.0)
+
+
+def test_the_rotation_is_the_shortest_arc():
+    """A shortest-arc rotation turns about an axis square to both directions."""
+    down = unit(np.array([0.4, -0.2, 0.6]))
+
+    rotation = _rotation_to_world_down(down)
+
+    expected_axis = unit(np.cross(down, WORLD_DOWN))
+    assert rotation * expected_axis == pytest.approx(expected_axis, abs=1e-6)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = gsplat_server mapping

--- a/scripts/run_stitch.sh
+++ b/scripts/run_stitch.sh
@@ -14,7 +14,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/docker_common.sh"
 
 REL_INSV="$(repo_relative_path "$1")"
 OUTPUT_VIDEO="${2:-${1%.*}_pano.mp4}"
-OUTPUT_SIZE="${3:-8000x4000}"
+OUTPUT_SIZE="${3:-4000x2000}"
 
 mkdir -p "$(dirname "${OUTPUT_VIDEO}")"
 REL_OUTPUT_VIDEO="$(repo_relative_path "${OUTPUT_VIDEO}")"


### PR DESCRIPTION
The repo had no tests and no test CI. This adds both.

## Tests

88 tests covering what runs without a GPU, COLMAP, or Triton. Each sits beside
the module it covers:

| test | covers |
| --- | --- |
| `gsplat_server/parameters_test.py` | The defaults layering — a partial parameters file keeps the shipped values instead of reading as proto3 zero, which is what `load_parameters` exists for. |
| `gsplat_server/server_test.py` | `JobStore` lifecycle and restart recovery, `extract_model`'s zip-slip rejection and wrapper-dir stripping, `job_steps` (an uploaded `masks/` is never overwritten), `write_upload`'s parameters-first rule, and the service's `NOT_FOUND` / `FAILED_PRECONDITION` paths. |
| `mapping/benchmark/summarize_gsplat_sweep_test.py` | Synthesized PLYs through `read_ply` / `ply_geometry`, the tag-tolerant `cfg.yml` loader, report sections, thumbnail splitting and staleness, and that `latest_step_file` orders by step rather than by name. |

The gRPC service is tested through its real servicer methods with real protobuf
messages; only the transport is stubbed, by a `FakeContext` whose `abort`
raises the way a real context does.

## CI

`.github/workflows/tests.yml` runs them in `container: python:3.11-slim`
(133 MB). The pipeline image was the obvious candidate, but at 20.6 GB it would
very likely exhaust a hosted runner's free disk, and the tested modules need
none of COLMAP, CUDA or Triton.

Neither image ships `protoc`, so `proto/build.sh` now falls back to the copy
`grpcio-tools` bundles when `protoc`/`grpc_python_plugin` are absent. That copy
is version-matched to the protobuf runtime installed alongside it, which also
removes the gencode/runtime skew risk an apt-installed `protoc` would carry.
The apt path is unchanged for existing hosts, and running the shipped script in
CI keeps it and `gsplat.proto` covered.

`docker.yml`'s path filter narrows from `artifacts/**` to `artifacts/docker/**`
so adding `artifacts/requirements-test.txt` cannot trigger an image rebuild.

## Verification

Both `build.sh` branches were run from a clean slate (no generated bindings):

- Host, system `protoc`: 88 passed.
- In `python:3.11-slim`, `protoc` confirmed absent so the fallback is used:
  88 passed. 43 s total including a cold image pull.

`testpaths = gsplat_server mapping` is load-bearing, not cosmetic: without it a
bare `pytest` collects `third_party/colmap`'s and `third_party/gsplat`'s own
suites, which need heavy native deps.

## Not covered

`mapping/train_gsplat_with_masks.py` and `mapping/segment_people.py` both
import torch at module scope, and the former runs the trainer at import time.
Covering its flag building needs a `__main__` guard first — a separate change,
since this PR doesn't otherwise touch those files.

## Review notes (§3)

`/simplify` ran over both the test bodies and the CI surface. Applied: a
hand-built job dict replaced with the real `JobStore.create`, four unexercised
helper parameters dropped, `run()`'s duplicate override mechanism folded into
`**overrides`, a 12³-point grid shrunk to 5³ for the same assertion, and
`build.sh`'s shared protoc flags hoisted into one array.

Skipped as false positives:

- Deriving the test helper's metric keys from `METRIC_COLUMNS` — the helper
  mirrors `collect_run`'s metrics dict, so that would couple it to the wrong
  source.
- A YAML anchor for the `paths:` list duplicated between the `push` and
  `pull_request` triggers — GitHub Actions does not support anchors, and the
  duplication matches `docker.yml`'s existing shape.
- Pinning CI's Python to the pipeline image's version. The tested modules run
  under 3.10 (the `gsplat` env) and 3.12 (the base env) in production, so no
  single pin matches; the tested surface is version-insensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)