### PR TITLE
Export gsplat point clouds in the input COLMAP frame

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ Mandatory rules for AI coding agents contributing to this repo. Direct user inst
 │   ├── mapping_pipeline.py       # The four mapping stages end to end.
 │   ├── gps.py                    # Capture GPS as UTM priors and map alignment.
 │   ├── gps_test.py               # Track parsing, the fit, and the alignment.
+│   ├── gsplat_world_frame.py     # Undo gsplat's world normalization on export.
+│   ├── gsplat_world_frame_test.py # Similarity inverse and the export wiring.
 │   ├── mapping_pipeline_test.py  # Gravity levelling of the solved map.
 │   ├── panorama_database.py      # Panorama video to a cube-map rig database.
 │   ├── segment_people.py         # Person masks for the training images.

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ Each `*_test.py` sits beside the module it covers, and between them they cover
 what runs without a GPU, COLMAP, or Triton: the `JobParameters` layering
 (`gsplat_server/parameters_test.py`), the training server's job store and
 archive handling (`gsplat_server/server_test.py`), the sweep report generator
-(`mapping/benchmark/summarize_gsplat_sweep_test.py`), and the reconstruction's
-gravity levelling (`mapping/mapping_pipeline_test.py`).
+(`mapping/benchmark/summarize_gsplat_sweep_test.py`), the reconstruction's
+gravity levelling (`mapping/mapping_pipeline_test.py`), and the point cloud's
+return to COLMAP coordinates (`mapping/gsplat_world_frame_test.py`).
 
 CI runs them on a slim Python image rather than the 20 GB pipeline one. To do
 the same locally:

--- a/doc/gsplat_server.md
+++ b/doc/gsplat_server.md
@@ -132,6 +132,11 @@ downloads the point cloud. The client requires Python 3 and `grpcio` and loads
 gsplat_server/client.py data/pano_mapping --server gsplat-host:50051 \
   --output pano.ply
 ```
+The downloaded point cloud is in the uploaded `sparse/` frame: gsplat
+normalizes world space for training (rotate, recenter, rescale), and the server
+reverses that similarity on export. So a point cloud overlays the COLMAP model
+it was trained from, and `local_to_world.json` still takes it to UTM.
+
 Pass `--parameters` with another text-format JobParameters file for a custom
 run. It is layered over the shipped defaults, so it only names what it changes:
 

--- a/doc/panorama_mapping.md
+++ b/doc/panorama_mapping.md
@@ -147,8 +147,8 @@ three frames have both a pose and a fix.
 
 The file stays in the mapping workspace. `gsplat_server/client.py` uploads
 `images/`, `sparse/` and `masks/` only, so a model trained on the server comes
-back without it; keep the workspace, or carry the file yourself, to put the
-trained model back in world coordinates.
+back in the `sparse/0/` frame but without it; keep the workspace, or carry the
+file yourself, to put the trained model back in world coordinates.
 
 `scripts/run_pipeline.sh` runs this stage between stitching and training as part
 of the whole pipeline, passing `TRITON_URL` through to it.

--- a/mapping/gsplat_world_frame.py
+++ b/mapping/gsplat_world_frame.py
@@ -1,0 +1,124 @@
+"""Undo gsplat's world normalization on exported Gaussian parameters.
+
+gsplat's COLMAP parser trains in a similarity-normalized frame (see
+`third_party/gsplat/examples/datasets/colmap.py`), but `simple_trainer` exports
+the raw parameters, so the saved point cloud lands in that frame rather than the
+input model's. The inverse similarity returns the means to the COLMAP frame and
+carries the Gaussian orientations and their (log) sizes along with it.
+"""
+import math
+
+import numpy as np
+
+
+def _rotation_quaternion(matrix):
+    """The wxyz quaternion of a 3x3 rotation matrix."""
+    trace = matrix[0, 0] + matrix[1, 1] + matrix[2, 2]
+    if trace > 0.0:
+        s = math.sqrt(trace + 1.0) * 2.0
+        quaternion = [
+            0.25 * s,
+            (matrix[2, 1] - matrix[1, 2]) / s,
+            (matrix[0, 2] - matrix[2, 0]) / s,
+            (matrix[1, 0] - matrix[0, 1]) / s,
+        ]
+    elif matrix[0, 0] > matrix[1, 1] and matrix[0, 0] > matrix[2, 2]:
+        s = math.sqrt(1.0 + matrix[0, 0] - matrix[1, 1] - matrix[2, 2]) * 2.0
+        quaternion = [
+            (matrix[2, 1] - matrix[1, 2]) / s,
+            0.25 * s,
+            (matrix[0, 1] + matrix[1, 0]) / s,
+            (matrix[0, 2] + matrix[2, 0]) / s,
+        ]
+    elif matrix[1, 1] > matrix[2, 2]:
+        s = math.sqrt(1.0 + matrix[1, 1] - matrix[0, 0] - matrix[2, 2]) * 2.0
+        quaternion = [
+            (matrix[0, 2] - matrix[2, 0]) / s,
+            (matrix[0, 1] + matrix[1, 0]) / s,
+            0.25 * s,
+            (matrix[1, 2] + matrix[2, 1]) / s,
+        ]
+    else:
+        s = math.sqrt(1.0 + matrix[2, 2] - matrix[0, 0] - matrix[1, 1]) * 2.0
+        quaternion = [
+            (matrix[1, 0] - matrix[0, 1]) / s,
+            (matrix[0, 2] + matrix[2, 0]) / s,
+            (matrix[1, 2] + matrix[2, 1]) / s,
+            0.25 * s,
+        ]
+    quaternion = np.asarray(quaternion, dtype=np.float64)
+    return quaternion / np.linalg.norm(quaternion)
+
+
+def _quaternion_product(left, right):
+    """Hamilton product of wxyz quaternions, which broadcasts `left` over `right`."""
+    left_w, left_x, left_y, left_z = left
+    right_w, right_x, right_y, right_z = np.moveaxis(right, -1, 0)
+    return np.stack(
+        [
+            left_w * right_w - left_x * right_x - left_y * right_y - left_z * right_z,
+            left_w * right_x + left_x * right_w + left_y * right_z - left_z * right_y,
+            left_w * right_y - left_x * right_z + left_y * right_w + left_z * right_x,
+            left_w * right_z + left_x * right_y - left_y * right_x + left_z * right_w,
+        ],
+        axis=-1,
+    )
+
+
+def restore_colmap_coordinates(transform, means, scales, quats):
+    """Map Gaussian parameters from gsplat's normalized frame back to COLMAP's.
+
+    `transform` is the parser's `transform`, the similarity taking the COLMAP
+    frame to the normalized one. `means` (N, 3) and `quats` (N, 4, wxyz) are the
+    exported arrays and `scales` (N, 3) the log-scales the PLY stores.
+    """
+    inverse = np.linalg.inv(transform)
+    # A similarity's linear part is `scale * rotation`; the determinant recovers
+    # the uniform scale, and stripping it leaves the inverse's rotation.
+    scale = float(abs(np.linalg.det(transform[:3, :3])) ** (1.0 / 3.0))
+    orientation = _rotation_quaternion(inverse[:3, :3] * scale)
+    means = np.asarray(means) @ inverse[:3, :3].T + inverse[:3, 3]
+    scales = np.asarray(scales) - math.log(scale)
+    quats = _quaternion_product(orientation, np.asarray(quats))
+    return means, scales, quats
+
+
+_scene_transform = None
+
+
+def capture_scene_transform(parser_class):
+    """Remember each parser's COLMAP-to-normalized transform for the exporter."""
+    original_init = parser_class.__init__
+
+    def __init__(self, *args, **kwargs):
+        global _scene_transform
+        original_init(self, *args, **kwargs)
+        _scene_transform = self.transform
+
+    parser_class.__init__ = __init__
+
+
+def export_in_colmap_frame(exporter_module):
+    """Make `export_splats` write point clouds in the input COLMAP frame.
+
+    `simple_trainer` imports `export_splats` from `gsplat`, so replacing the
+    attribute reaches it; the transform `capture_scene_transform` recorded is
+    undone on every export.
+    """
+    original_export = exporter_module.export_splats
+
+    def export_splats(*args, **kwargs):
+        if _scene_transform is not None:
+            means, scales, quats = kwargs["means"], kwargs["scales"], kwargs["quats"]
+            restored = restore_colmap_coordinates(
+                _scene_transform,
+                means.detach().cpu().numpy(),
+                scales.detach().cpu().numpy(),
+                quats.detach().cpu().numpy(),
+            )
+            kwargs["means"] = means.new_tensor(restored[0])
+            kwargs["scales"] = scales.new_tensor(restored[1])
+            kwargs["quats"] = quats.new_tensor(restored[2])
+        return original_export(*args, **kwargs)
+
+    exporter_module.export_splats = export_splats

--- a/mapping/gsplat_world_frame_test.py
+++ b/mapping/gsplat_world_frame_test.py
@@ -1,0 +1,138 @@
+import types
+
+import numpy as np
+
+from mapping.gsplat_world_frame import (
+    _rotation_quaternion,
+    capture_scene_transform,
+    export_in_colmap_frame,
+    restore_colmap_coordinates,
+)
+
+
+def _quaternion_to_rotation(quaternion):
+    """wxyz quaternion(s) to rotation matrix/matrices."""
+    w, x, y, z = np.moveaxis(quaternion, -1, 0)
+    return np.stack(
+        [
+            np.stack([1 - 2 * (y**2 + z**2), 2 * (x * y - w * z), 2 * (x * z + w * y)], -1),
+            np.stack([2 * (x * y + w * z), 1 - 2 * (x**2 + z**2), 2 * (y * z - w * x)], -1),
+            np.stack([2 * (x * z - w * y), 2 * (y * z + w * x), 1 - 2 * (x**2 + y**2)], -1),
+        ],
+        -2,
+    )
+
+
+def _normalized_quaternions(rng, count):
+    quaternions = rng.normal(size=(count, 4))
+    return quaternions / np.linalg.norm(quaternions, axis=-1, keepdims=True)
+
+
+class _FakeTensor:
+    """The sliver of the torch API `export_in_colmap_frame` touches."""
+
+    def __init__(self, array):
+        self.array = np.asarray(array)
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self.array
+
+    def new_tensor(self, array):
+        return _FakeTensor(array)
+
+
+def test_restores_similarity_normalized_parameters():
+    rng = np.random.default_rng(0)
+    count = 64
+
+    rotation = _quaternion_to_rotation(_normalized_quaternions(rng, 1)[0])
+    scale = 3.7
+    translation = rng.normal(size=3)
+    transform = np.eye(4)
+    transform[:3, :3] = scale * rotation
+    transform[:3, 3] = translation
+
+    points = rng.normal(size=(count, 3))
+    gaussian_rotation = _quaternion_to_rotation(_normalized_quaternions(rng, count))
+    gaussian_scale = rng.uniform(0.01, 1.0, size=(count, 3))
+
+    normalized_points = points @ (scale * rotation).T + translation
+    normalized_rotation = rotation @ gaussian_rotation
+    normalized_scale = scale * gaussian_scale
+    normalized_quats = np.stack(
+        [_rotation_quaternion(matrix) for matrix in normalized_rotation]
+    )
+
+    means, scales, quats = restore_colmap_coordinates(
+        transform,
+        normalized_points,
+        np.log(normalized_scale),
+        normalized_quats,
+    )
+
+    assert np.allclose(means, points, atol=1e-4)
+    assert np.allclose(np.exp(scales), gaussian_scale, rtol=1e-4)
+    assert np.allclose(_quaternion_to_rotation(quats), gaussian_rotation, atol=1e-4)
+
+
+def test_identity_transform_leaves_parameters_unchanged():
+    rng = np.random.default_rng(1)
+    means = rng.normal(size=(8, 3))
+    scales = rng.normal(size=(8, 3))
+    quats = _normalized_quaternions(rng, 8)
+
+    restored_means, restored_scales, restored_quats = restore_colmap_coordinates(
+        np.eye(4), means, scales, quats
+    )
+
+    assert np.allclose(restored_means, means, atol=1e-6)
+    assert np.allclose(restored_scales, scales, atol=1e-6)
+    assert np.allclose(
+        _quaternion_to_rotation(restored_quats),
+        _quaternion_to_rotation(quats),
+        atol=1e-6,
+    )
+
+
+def test_captured_transform_is_undone_on_export():
+    rng = np.random.default_rng(2)
+    rotation = _quaternion_to_rotation(_normalized_quaternions(rng, 1)[0])
+    scale = 2.0
+    translation = rng.normal(size=3)
+    transform = np.eye(4)
+    transform[:3, :3] = scale * rotation
+    transform[:3, 3] = translation
+
+    class StubParser:
+        def __init__(self):
+            self.transform = transform
+
+    exported = {}
+
+    def original_export(*args, **kwargs):
+        exported.update(kwargs)
+
+    exporter = types.SimpleNamespace(export_splats=original_export)
+    capture_scene_transform(StubParser)
+    export_in_colmap_frame(exporter)
+    StubParser()
+
+    count = 16
+    points = rng.normal(size=(count, 3))
+    normalized_points = points @ (scale * rotation).T + translation
+    exporter.export_splats(
+        means=_FakeTensor(normalized_points),
+        scales=_FakeTensor(np.zeros((count, 3))),
+        quats=_FakeTensor(np.tile([1.0, 0.0, 0.0, 0.0], (count, 1))),
+        opacities=_FakeTensor(np.zeros(count)),
+        sh0=_FakeTensor(np.zeros((count, 1, 3))),
+        shN=_FakeTensor(np.zeros((count, 0, 3))),
+    )
+
+    assert np.allclose(exported["means"].array, points, atol=1e-4)

--- a/mapping/train_gsplat_with_masks.py
+++ b/mapping/train_gsplat_with_masks.py
@@ -42,9 +42,15 @@ def attach_masks(dataset_class):
 
 
 sys.path.insert(0, EXAMPLES_DIR)
-from datasets.colmap import Dataset  # noqa: E402
+import gsplat  # noqa: E402
+from datasets.colmap import Dataset, Parser  # noqa: E402
 from gsplat_server.parameters import load_parameters  # noqa: E402
 from gsplat_server.proto import gsplat_pb2  # noqa: E402
+from mapping.gsplat_world_frame import (  # noqa: E402
+    capture_scene_transform,
+    export_in_colmap_frame,
+)
+
 
 def number(value):
     """Recover the decimal the parameter file was written with.
@@ -119,4 +125,6 @@ def load_job_parameters():
 
 load_job_parameters()
 attach_masks(Dataset)
+capture_scene_transform(Parser)
+export_in_colmap_frame(gsplat)
 runpy.run_path(os.path.join(EXAMPLES_DIR, "simple_trainer.py"), run_name="__main__")


### PR DESCRIPTION
## Problem

The point cloud gsplat trains is not in the same coordinates as the COLMAP model it was trained from.

gsplat's COLMAP parser normalizes world space before training — a similarity `T = T3 @ T2 @ T1` (rotate to an up-axis, align principal axes, recenter, rescale to unit camera distance), applied to both points and poses — and `normalize_world_space` defaults to true. `simple_trainer` then exports the raw `means`/`scales`/`quats`, so the PLY lands in that normalized frame.

Evidence from an existing run: `data/panorama/gsplat_output/cfg.yml` records `normalize_world_space: true`, and its PLY extents (11.9 x 7.6 x 14.4) differ from its COLMAP model (121.9 x 169.5 x 226.8) by a rotation plus roughly 15x scale.

## Fix

Training stays in gsplat's normalized frame, so the tuned dynamics are untouched; the similarity is undone only at export.

* `mapping/gsplat_world_frame.py` — `restore_colmap_coordinates` inverts the transform on the means, rotates the Gaussian quaternions by the inverse's rotation, and shifts the log-scales by `-log(scale)`. Numpy-only, so the tests need no torch. `capture_scene_transform` records the parser's transform; `export_in_colmap_frame` replaces `gsplat.export_splats`, which is exactly what `simple_trainer` imports.
* `mapping/train_gsplat_with_masks.py` — wires both hooks in before the trainer runs. Both the gRPC server and `scripts/run_pipeline.sh` go through this entrypoint.
* `mapping/gsplat_world_frame_test.py` — covers the similarity inverse, the identity case, and the capture/export wiring.

Docs (`doc/gsplat_server.md`, `doc/panorama_mapping.md`, `README.md`, `AGENTS.md`) updated to state that the downloaded cloud is in the uploaded `sparse/` frame.

## Verification

* Drove the real gsplat export path with torch tensors and read the PLY back: means match the COLMAP frame to 1.7e-6, and `scale_*` shifts by exactly `-log(s)`.
* Confirmed `from gsplat import export_splats` binds the patched function.
* `pytest gsplat_server mapping/gsplat_world_frame_test.py mapping/benchmark` — 91 passed.

Not run: an actual training job (no GPU available), so the full trainer path is verified through the export simulation above rather than a live run.

Note: PLYs already on disk were produced before this change and remain in the normalized frame; re-run training to get COLMAP-frame output.